### PR TITLE
Configuration module leveraging pydantic-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,33 @@ A suite of modules to enable TDA/MMA observations
 
 [issues](https://github.com/AEONplus/AEONlib/issues)
 
+### Configuration
+Many of the facilities and services accessed by AEONlib require specific configuration such
+as api keys, urls, etc. All configuration can be supplied by either supplying a .env file or
+setting environmental variables in the execution environment.
+
+Example .env file:
+
+```
+AEON_LCO_API_ROOT="https://observe.lco.global/api"
+AEON_LCO_TOKEN="my-api-token"
+```
+
+Or set environmental variables via the shell:
+
+```bash
+export AEON_LCO_API_ROOT="https://observe.lco.global/api"
+export AEON_LCO_TOKEN="my-api-token"
+```
+
+All configuration keys are prefixed with AEON_ to prevent conflicts. See the documentation for
+each service to see which configuration keys are available, or check
+[conf.py](src/aeonlib/conf.py)
+
+Environmental variables take precedence over .env files. See the
+[pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) documentation
+for more details.
+
 
 ### Testing
 This project uses [pytest](https://docs.pytest.org/) to run tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "astropy>=7.0.1",
     "httpx>=0.28.1",
     "pydantic>=2.11.1",
+    "pydantic-settings>=2.9.1",
 ]
 
 [build-system]

--- a/src/aeonlib/conf.py
+++ b/src/aeonlib/conf.py
@@ -1,0 +1,11 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="AEON_", env_file=".env")
+
+    lco_token: str = ""
+    lco_api_root: str = "https://observe.lco.global/api/"
+
+
+settings = Settings()

--- a/tests/ocs/test_online_validation.py
+++ b/tests/ocs/test_online_validation.py
@@ -11,7 +11,6 @@ on all instruments.
 """
 
 import logging
-import os
 
 import pytest
 
@@ -26,8 +25,7 @@ pytestmark = pytest.mark.online
 
 @pytest.fixture
 def facility() -> LcoFacility:
-    api_root = os.getenv("AEONLIB_TEST_OCS", "http://localhost:8000/api")
-    return LcoFacility(api_root=api_root)
+    return LcoFacility()
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ dependencies = [
     { name = "astropy" },
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
 ]
 
 [package.dev-dependencies]
@@ -26,6 +27,7 @@ requires-dist = [
     { name = "astropy", specifier = ">=7.0.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.11.1" },
+    { name = "pydantic-settings", specifier = ">=2.9.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -333,6 +335,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234, upload_time = "2025-04-18T16:44:48.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356, upload_time = "2025-04-18T16:44:46.617Z" },
+]
+
+[[package]]
 name = "pyerfa"
 version = "2.0.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -363,6 +379,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload_time = "2025-03-02T12:54:54.503Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload_time = "2025-03-02T12:54:52.069Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload_time = "2025-03-25T10:14:56.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload_time = "2025-03-25T10:14:55.034Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In anticipation of including additional facilities, this commit adds configuration management via pydantic-settings. This enables library users to supply .env files or environmental variables to configure their appliction. This enables a single, consistent place to configure all services included in Aeonlib.