### PR TITLE
ESO module for the Phase 2 submission process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project
-        run: uv sync --dev
+        run: uv sync --dev --group eso
 
       - name: Run tests
         run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A suite of modules to enable TDA/MMA observations
 
 [issues](https://github.com/AEONplus/AEONlib/issues)
 
-### Configuration
+# Configuration
 Many of the facilities and services accessed by AEONlib require specific configuration such
 as api keys, urls, etc. All configuration can be supplied by either supplying a .env file or
 setting environmental variables in the execution environment.
@@ -34,26 +34,45 @@ Environmental variables take precedence over .env files. See the
 for more details.
 
 
-### Testing
+# Testing
 This project uses [pytest](https://docs.pytest.org/) to run tests:
 
-```shell
+```bash
 pytest
 ```
 
 Some tests are marked as `online`. These tests make real http requests in order
 to test interfaces with various services. To run them:
 
-```shell
+```bash
 pytest -m online
+```
+
+A subset of `online` tests are marked as `side_effect`. These are tests that change data on remote
+systems. For example, a test might be testing creating new observation requests, or updating the
+status of one. You might want to disable these:
+
+```bash
+pytest -m "not side_effect"
 ```
 
 CI does not run tests marked as online.
 
-### Linting
+## Viewing logs during tests
+Aeonlib turns on the Pytest
+[Live Logging](https://docs.pytest.org/en/stable/how-to/logging.html#live-logs) feature.
+By default any logging calls with a level above `WARNING` will be displayed to the console
+during the test run. It may be helpful to display debug logging, especially if debugging remote
+facilities or services:
+
+```bash
+pytest -m online --log-cli-level=debug
+```
+
+# Linting
 All code is formatted via [ruff](https://astral.sh/ruff).
 
-### Code Generation
+# Code Generation
 Las Cumbres Observatory [instrument classes](src/aeonlib/ocs/lco/instruments.py)
 are generated via the [generator.py](codegen/lco/generator.py) script. This script
 takes as input the [OCS instruments api](https://observe.lco.global/api/instruments/)
@@ -62,7 +81,7 @@ in order to produce definitions of all instruments currently available on the ne
 To update the definitions, first make sure you have installed the `codegen` dependency
 group:
 
-```shell
+```bash
 uv sync --group codegen  # or poetry install --with codegen
 ```
 
@@ -70,19 +89,71 @@ This ensures regular users of the library do not need to install these dependenc
 
 The `generate.py` script takes as input JSON as produced by the instruments endpoint:
 
-```shell
+```bash
 codegen/lco/generator.py instruments.json
 ```
 
 Or directly from stdin using a pipe:
 
-```shell
+```bash
 curl https://observe.lco.global/api/instruments/ | codegen/lco/generator.py
 ```
 
 If the output looks satisfactory, you can redirect the output to overwrite the
 LCO instruments definition file:
 
-```shell
+```bash
 curl https://observe.lco.global/api/instruments/ | codegen/lco/generator.py > src/aeonlib/ocs/lco/instruments.py
 ```
+# Supported Facilities
+
+This list is a work in progress.
+
+## OCS (Las Cumbres Observatory)
+
+Full documentation: TODO
+
+
+### Dependency group
+The OCS requires no additional dependency groups to be installed.
+
+### Configuration Values
+See [configuration](#configuration) for instructions on setting these values.
+
+For LCO:
+
+```python
+lco_token: str = ""
+lco_api_root: str = "https://observe.lco.global/api/"
+```
+### Helpful links
+
+* [LCO Observation Portal](https://observe.lco.global/)
+* [LCO Developer Documentation](https://developers.lco.global/)
+* [OCS API Documentation](https://observatorycontrolsystem.github.io/api/observation_portal/)
+
+## ESO (European Southern Observatory)
+
+Full documentation: TODO
+
+### Dependency Group
+To use the ESO facility, you must install the `eso` group:
+```bash
+pip install aeonlib[eso]
+uv sync --group eso
+poetry install --with eso
+```
+
+### Configuration Values
+See [configuration](#configuration) for instructions on setting these values.
+
+```python
+eso_environment: str = "demo"
+eso_username: str = ""
+eso_password: str = ""
+```
+
+### Helpul links
+
+* [ESO Phase 2 API](https://www.eso.org/sci/observing/phase2/p2intro/Phase2API.html)
+* [ESO Phase 2 Demo Application](https://www.eso.org/p2demo/home)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,4 @@ markers = [
     "side_effect: Online tests that have side effects such as creating observation requests",
 ]
 log_cli = true
+log_cli_format = "%(levelname)s [%(name)s %(filename)s:%(lineno)s %(funcName)s()] %(message)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,12 @@ codegen = [
 ]
 
 dev = ["pytest>=8.3.5"]
+eso = ["p2api>=1.0.10"]
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib",  "-m not online"]
 markers = [
-    "online: Marks tests that run online, for example, validating schemas"
+    "online: Marks tests that run online, for example, validating schemas",
+    "side_effect: Online tests that have side effects such as creating observation requests",
 ]
+log_cli = true

--- a/src/aeonlib/conf.py
+++ b/src/aeonlib/conf.py
@@ -4,8 +4,14 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="AEON_", env_file=".env")
 
+    # Las Cumbres Observatory
     lco_token: str = ""
     lco_api_root: str = "https://observe.lco.global/api/"
+
+    # European Southern Observatory
+    eso_environment: str = "demo"
+    eso_username: str = ""
+    eso_password: str = ""
 
 
 settings = Settings()

--- a/src/aeonlib/eso/facility.py
+++ b/src/aeonlib/eso/facility.py
@@ -1,8 +1,9 @@
 import logging
 
 from aeonlib.conf import settings as default_settings
+from aeonlib.exceptions import ServiceNetworkError
 
-from .models import Container
+from .models import Container, ObservationBlock
 
 logger = logging.getLogger(__name__)
 
@@ -11,6 +12,10 @@ try:
 except ImportError as e:
     logger.critical("p2api not found. Install the 'eso' dependency group for Aeonlib.")
     raise e
+
+
+class ESONetworkError(ServiceNetworkError):
+    pass
 
 
 class EsoFacility:
@@ -23,6 +28,45 @@ class EsoFacility:
         )
 
     def create_folder(self, container_id: int, name: str) -> Container:
-        container, tx_id = self.api.createFolder(container_id, name)
-        logger.debug("EsoFacility.create_folder <- %s (%s)", container, tx_id)
-        return Container.model_validate(container)
+        container, version = self.api.createFolder(container_id, name)
+        if not container or not version:
+            raise ESONetworkError("Failed to create ESO folder")
+        logger.debug("EsoFacility.create_folder <- %s (%s)", container, version)
+        return Container.model_validate({**container, "version": version})
+
+    def get_container(self, container_id: int) -> Container:
+        container, version = self.api.getContainer(container_id)
+        if not container or not version:
+            raise ESONetworkError("Failed to get ESO container")
+        logger.debug("EsoFacility.get_container <- %s (%s)", container, version)
+        return Container.model_validate({**container, "version": version})
+
+    def delete_container(self, container: Container) -> None:
+        self.api.deleteContainer(container.container_id, container.version)
+
+    def create_ob(self, container: Container, name: str) -> ObservationBlock:
+        ob, version = self.api.createOB(container.container_id, name)
+        if not ob or not version:
+            raise ESONetworkError("Failed to create ESO observation block")
+        logger.debug("EsoFacility.create_observation_block <- %s (%s)", ob, version)
+        ob = ObservationBlock.model_validate({**ob, "version": version})
+        return ob
+
+    def get_ob(self, ob_id: int) -> ObservationBlock:
+        ob, version = self.api.getOB(ob_id)
+        if not ob or not version:
+            raise ESONetworkError("Failed to get ESO observation block")
+        logger.debug("EsoFacility.get_observation_block <- %s (%s)", ob, version)
+        return ObservationBlock.model_validate({**ob, "version": version})
+
+    def save_ob(self, ob: ObservationBlock) -> ObservationBlock:
+        ob_dict = ob.model_dump(exclude={"version"})
+        logger.debug("EsoFacility.save_ob -> %s", ob_dict)
+        new_ob_dict, version = self.api.saveOB(ob_dict, ob.version)
+        if not new_ob_dict or not version:
+            raise ESONetworkError("Failed to update ESO observation block")
+        logger.debug("EsoFacility.save_ob <- %s (%s)", new_ob_dict, version)
+        return ObservationBlock.model_validate({**new_ob_dict, "version": version})
+
+    def delete_ob(self, ob: ObservationBlock) -> None:
+        self.api.deleteOB(ob.ob_id, ob.version)

--- a/src/aeonlib/eso/facility.py
+++ b/src/aeonlib/eso/facility.py
@@ -3,7 +3,7 @@ import logging
 from aeonlib.conf import settings as default_settings
 from aeonlib.exceptions import ServiceNetworkError
 
-from .models import Container, ObservationBlock
+from .models import Container, ObservationBlock, Template
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class EsoFacility:
             assert container and version
         except Exception as e:
             raise ESONetworkError("Failed to create ESO folder") from e
-        logger.debug("EsoFacility.create_folder <- %s (%s)", container, version)
+        logger.debug("<- %s (%s)", container, version)
 
         return Container.model_validate({**container, "version": version})
 
@@ -43,7 +43,7 @@ class EsoFacility:
             assert container and version
         except Exception as e:
             raise ESONetworkError("Failed to get ESO container") from e
-        logger.debug("EsoFacility.get_container <- %s (%s)", container, version)
+        logger.debug("<- %s (%s)", container, version)
 
         return Container.model_validate({**container, "version": version})
 
@@ -59,7 +59,7 @@ class EsoFacility:
             assert ob and version
         except Exception as e:
             raise ESONetworkError("Failed to create ESO observation block") from e
-        logger.debug("EsoFacility.create_observation_block <- %s (%s)", ob, version)
+        logger.debug("<- %s (%s)", ob, version)
 
         return ObservationBlock.model_validate({**ob, "version": version})
 
@@ -69,19 +69,19 @@ class EsoFacility:
             assert ob and version
         except Exception as e:
             raise ESONetworkError("Failed to get ESO observation block") from e
-        logger.debug("EsoFacility.get_observation_block <- %s (%s)", ob, version)
+        logger.debug("<- %s (%s)", ob, version)
 
         return ObservationBlock.model_validate({**ob, "version": version})
 
     def save_ob(self, ob: ObservationBlock) -> ObservationBlock:
         ob_dict = ob.model_dump(exclude={"version"})
-        logger.debug("EsoFacility.save_ob -> %s", ob_dict)
+        logger.debug("-> %s", ob_dict)
         try:
             new_ob_dict, version = self.api.saveOB(ob_dict, ob.version)
             assert new_ob_dict and version
         except Exception as e:
             raise ESONetworkError("Failed to update ESO observation block") from e
-        logger.debug("EsoFacility.save_ob <- %s (%s)", new_ob_dict, version)
+        logger.debug("<- %s (%s)", new_ob_dict, version)
 
         return ObservationBlock.model_validate({**new_ob_dict, "version": version})
 

--- a/src/aeonlib/eso/facility.py
+++ b/src/aeonlib/eso/facility.py
@@ -28,45 +28,65 @@ class EsoFacility:
         )
 
     def create_folder(self, container_id: int, name: str) -> Container:
-        container, version = self.api.createFolder(container_id, name)
-        if not container or not version:
-            raise ESONetworkError("Failed to create ESO folder")
+        try:
+            container, version = self.api.createFolder(container_id, name)
+            assert container and version
+        except Exception as e:
+            raise ESONetworkError("Failed to create ESO folder") from e
         logger.debug("EsoFacility.create_folder <- %s (%s)", container, version)
+
         return Container.model_validate({**container, "version": version})
 
     def get_container(self, container_id: int) -> Container:
-        container, version = self.api.getContainer(container_id)
-        if not container or not version:
-            raise ESONetworkError("Failed to get ESO container")
+        try:
+            container, version = self.api.getContainer(container_id)
+            assert container and version
+        except Exception as e:
+            raise ESONetworkError("Failed to get ESO container") from e
         logger.debug("EsoFacility.get_container <- %s (%s)", container, version)
+
         return Container.model_validate({**container, "version": version})
 
     def delete_container(self, container: Container) -> None:
-        self.api.deleteContainer(container.container_id, container.version)
+        try:
+            self.api.deleteContainer(container.container_id, container.version)
+        except Exception as e:
+            raise ESONetworkError("Failed to delete ESO container") from e
 
     def create_ob(self, container: Container, name: str) -> ObservationBlock:
-        ob, version = self.api.createOB(container.container_id, name)
-        if not ob or not version:
-            raise ESONetworkError("Failed to create ESO observation block")
+        try:
+            ob, version = self.api.createOB(container.container_id, name)
+            assert ob and version
+        except Exception as e:
+            raise ESONetworkError("Failed to create ESO observation block") from e
         logger.debug("EsoFacility.create_observation_block <- %s (%s)", ob, version)
-        ob = ObservationBlock.model_validate({**ob, "version": version})
-        return ob
+
+        return ObservationBlock.model_validate({**ob, "version": version})
 
     def get_ob(self, ob_id: int) -> ObservationBlock:
-        ob, version = self.api.getOB(ob_id)
-        if not ob or not version:
-            raise ESONetworkError("Failed to get ESO observation block")
+        try:
+            ob, version = self.api.getOB(ob_id)
+            assert ob and version
+        except Exception as e:
+            raise ESONetworkError("Failed to get ESO observation block") from e
         logger.debug("EsoFacility.get_observation_block <- %s (%s)", ob, version)
+
         return ObservationBlock.model_validate({**ob, "version": version})
 
     def save_ob(self, ob: ObservationBlock) -> ObservationBlock:
         ob_dict = ob.model_dump(exclude={"version"})
         logger.debug("EsoFacility.save_ob -> %s", ob_dict)
-        new_ob_dict, version = self.api.saveOB(ob_dict, ob.version)
-        if not new_ob_dict or not version:
-            raise ESONetworkError("Failed to update ESO observation block")
+        try:
+            new_ob_dict, version = self.api.saveOB(ob_dict, ob.version)
+            assert new_ob_dict and version
+        except Exception as e:
+            raise ESONetworkError("Failed to update ESO observation block") from e
         logger.debug("EsoFacility.save_ob <- %s (%s)", new_ob_dict, version)
+
         return ObservationBlock.model_validate({**new_ob_dict, "version": version})
 
     def delete_ob(self, ob: ObservationBlock) -> None:
-        self.api.deleteOB(ob.ob_id, ob.version)
+        try:
+            self.api.deleteOB(ob.ob_id, ob.version)
+        except Exception as e:
+            raise ESONetworkError("Failed to delete ESO observation block") from e

--- a/src/aeonlib/eso/facility.py
+++ b/src/aeonlib/eso/facility.py
@@ -1,0 +1,28 @@
+import logging
+
+from aeonlib.conf import settings as default_settings
+
+from .models import Container
+
+logger = logging.getLogger(__name__)
+
+try:
+    import p2api
+except ImportError as e:
+    logger.critical("p2api not found. Install the 'eso' dependency group for Aeonlib.")
+    raise e
+
+
+class EsoFacility:
+    def __init__(self, settings=default_settings):
+        self.api = p2api.ApiConnection(
+            settings.eso_environment,
+            settings.eso_username,
+            settings.eso_password,
+            debug=True,
+        )
+
+    def create_folder(self, container_id: int, name: str) -> Container:
+        container, tx_id = self.api.createFolder(container_id, name)
+        logger.debug("EsoFacility.create_folder <- %s (%s)", container, tx_id)
+        return Container.model_validate(container)

--- a/src/aeonlib/eso/facility.py
+++ b/src/aeonlib/eso/facility.py
@@ -307,3 +307,22 @@ class EsoFacility:
             self.api.deleteFindingChart(ob.ob_id, index)
         except Exception as e:
             raise ESONetworkError("Failed to delete ESO finding chart") from e
+
+    def verify(self, ob: ObservationBlock, submit: bool) -> tuple[list[str], bool]:
+        """Verify an observation block is observable.
+        Parameters:
+            ob (ObservationBlock): The observation block to verify.
+            submit (bool): Whether to change the status of the block to defined or executable.
+        Returns:
+            tuple[list[str], bool]: A tuple of error messages and success indicator.
+        """
+        try:
+            response, _ = self.api.verifyOB(ob.ob_id, submit)
+            assert response
+        except Exception as e:
+            raise ESONetworkError("Failed to verify ESO observation block") from e
+        logger.debug("<- %s", response)
+        if response.get("observable"):
+            return [], True
+        else:
+            return response.get("messages", []), False

--- a/src/aeonlib/eso/facility.py
+++ b/src/aeonlib/eso/facility.py
@@ -90,3 +90,19 @@ class EsoFacility:
             self.api.deleteOB(ob.ob_id, ob.version)
         except Exception as e:
             raise ESONetworkError("Failed to delete ESO observation block") from e
+
+    def create_template(self, ob: ObservationBlock, name: str) -> Template:
+        try:
+            template, version = self.api.createTemplate(ob.ob_id, name)
+            assert template and version
+        except Exception as e:
+            raise ESONetworkError("Failed to create ESO template") from e
+        logger.debug("<- %s (%s)", template, version)
+
+        return Template.model_validate({**template, "version": version})
+
+    def delete_template(self, ob: ObservationBlock, template: Template) -> None:
+        try:
+            self.api.deleteTemplate(ob.ob_id, template.template_id, template.version)
+        except Exception as e:
+            raise ESONetworkError("Failed to delete ESO template") from e

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -8,6 +8,55 @@ class EsoModel(BaseModel):
     )
 
 
+class Constraints(EsoModel):
+    airmass: float
+    fli: float
+    moon_distance: int
+    name: str
+    seeing: float
+    sky_transparency: str
+    twilight: int
+    water_vapour: float
+
+
+class ObsDescription(EsoModel):
+    instrument_comments: str
+    name: str
+    user_comments: str
+
+
+class Target(EsoModel):
+    dec: str
+    differential_dec: float
+    differential_ra: float
+    epoch: float
+    equinox: str
+    name: str
+    proper_motion_dec: float
+    proper_motion_ra: float
+    ra: str
+
+
+class ObservationBlock(EsoModel):
+    version: str
+    constraints: Constraints
+    obs_description: ObsDescription
+    target: Target
+    execution_time: int
+    exposure_time: int
+    instrument: str
+    ip_version: float
+    item_type: str
+    migrate: bool
+    grade: str = "?"
+    name: str
+    ob_id: int
+    ob_status: str
+    parent_container_id: int
+    run_id: int
+    user_priority: int
+
+
 class Container(EsoModel):
     container_id: int
     item_count: int
@@ -15,3 +64,4 @@ class Container(EsoModel):
     name: str
     parent_container_id: int
     run_id: int
+    version: str

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -1,8 +1,10 @@
 from datetime import datetime, time
-from typing import Any
+from typing import Any, Self
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
+
+from aeonlib.models import Window
 
 
 class EsoModel(BaseModel):
@@ -86,6 +88,13 @@ class AbsoluteTimeConstraint(EsoModel):
     # Fields are aliased due to from being a reserved keyword in Python
     start: datetime = Field(..., serialization_alias="from", validation_alias="from")
     end: datetime = Field(..., serialization_alias="to", validation_alias="to")
+
+    @classmethod
+    def from_window(cls, window: Window) -> Self:
+        if not window.start:
+            raise ValueError("ESO constraints require a valid start time")
+        else:
+            return cls.model_validate(window.model_dump(mode="json"))
 
 
 class AbsoluteTimeConstraints(EsoModel):

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -102,3 +102,8 @@ class SiderealTimeConstraint(EsoModel):
 class SiderealTimeConstraints(EsoModel):
     constraints: list[SiderealTimeConstraint]
     version: str | None = None
+
+
+class Ephemeris(EsoModel):
+    text: str
+    version: str | None = None

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
@@ -64,4 +66,15 @@ class Container(EsoModel):
     name: str
     parent_container_id: int
     run_id: int
+    version: str
+
+
+class Template(EsoModel):
+    template_id: int
+    template_name: str
+    type: str
+    parameters: list[dict[str, Any]]
+    """
+    TODO: see if we can auto-generate these somehow
+    """
     version: str

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 
@@ -77,4 +78,27 @@ class Template(EsoModel):
     """
     TODO: see if we can auto-generate these somehow
     """
+    version: str
+
+
+# TODO figure out how to use a general Window class for these constraints
+class AbsoluteTimeConstraint(EsoModel):
+    # Fields are aliased due to from being a reserved keyword in Python
+    start: datetime = Field(..., serialization_alias="from", validation_alias="from")
+    end: datetime = Field(..., serialization_alias="to", validation_alias="to")
+
+
+class AbsoluteTimeConstraints(EsoModel):
+    constraints: list[AbsoluteTimeConstraint]
+    version: str
+
+
+class SiderealTimeConstraint(EsoModel):
+    # Fields are aliased due to from being a reserved keyword in Python
+    start: str = Field(..., serialization_alias="from", validation_alias="from")
+    end: str = Field(..., serialization_alias="to", validation_alias="to")
+
+
+class SiderealTimeConstraints(EsoModel):
+    constraints: list[SiderealTimeConstraint]
     version: str

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -90,7 +90,7 @@ class AbsoluteTimeConstraint(EsoModel):
 
 class AbsoluteTimeConstraints(EsoModel):
     constraints: list[AbsoluteTimeConstraint]
-    version: str
+    version: str | None = None
 
 
 class SiderealTimeConstraint(EsoModel):
@@ -101,4 +101,4 @@ class SiderealTimeConstraint(EsoModel):
 
 class SiderealTimeConstraints(EsoModel):
     constraints: list[SiderealTimeConstraint]
-    version: str
+    version: str | None = None

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, time
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -95,8 +95,8 @@ class AbsoluteTimeConstraints(EsoModel):
 
 class SiderealTimeConstraint(EsoModel):
     # Fields are aliased due to from being a reserved keyword in Python
-    start: str = Field(..., serialization_alias="from", validation_alias="from")
-    end: str = Field(..., serialization_alias="to", validation_alias="to")
+    start: time = Field(..., serialization_alias="from", validation_alias="from")
+    end: time = Field(..., serialization_alias="to", validation_alias="to")
 
 
 class SiderealTimeConstraints(EsoModel):

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class EsoModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel, validate_by_name=True, serialize_by_alias=True
+    )
+
+
+class Container(EsoModel):
+    container_id: int
+    item_count: int
+    item_type: str
+    name: str
+    parent_container_id: int
+    run_id: int

--- a/src/aeonlib/exceptions.py
+++ b/src/aeonlib/exceptions.py
@@ -1,0 +1,2 @@
+class ServiceNetworkError(Exception):
+    pass

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -1,0 +1,17 @@
+"""
+Models shared between facilities.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from aeonlib.types import Time
+
+
+class Window(BaseModel):
+    """A general time window"""
+
+    model_config = ConfigDict(validate_assignment=True)
+    start: Time | datetime | None = None
+    end: Time | datetime

--- a/src/aeonlib/ocs/__init__.py
+++ b/src/aeonlib/ocs/__init__.py
@@ -1,11 +1,10 @@
-from .request_models import Location, Request, RequestGroup, Window
+from .request_models import Location, Request, RequestGroup
 from .target_models import Constraints, NonSiderealTarget, SiderealTarget
 
 __all__ = [
     "Location",
     "Request",
     "RequestGroup",
-    "Window",
     "Constraints",
     "SiderealTarget",
     "NonSiderealTarget",

--- a/src/aeonlib/ocs/lco/facility.py
+++ b/src/aeonlib/ocs/lco/facility.py
@@ -64,7 +64,7 @@ class LcoFacility:
         logger.debug("LcoFacility.validate_request_group -> %s", payload)
         response = self.client.post("/requestgroups/validate/", json=payload)
         response = response.json()
-        logger.debug("LcoFacility.validate_request_group <- %s", response)
+        logger.debug("<- %s", response)
         if response["request_durations"]:
             return True, []
         else:
@@ -74,8 +74,8 @@ class LcoFacility:
         self, request_group: RequestGroup
     ) -> SubmittedRequestGroup:
         payload = request_group.model_dump(mode="json", exclude_none=True)
-        logger.debug("LcoFacility.submit_request_group -> %s", payload)
+        logger.debug("-> %s", payload)
         response = self.client.post("/requestgroups/", json=payload)
         response.raise_for_status()
-        logger.debug("LcoFacility.submit_request_group <- %s", response.content)
+        logger.debug("<- %s", response.content)
         return SubmittedRequestGroup.model_validate_json(response.content)

--- a/src/aeonlib/ocs/request_models.py
+++ b/src/aeonlib/ocs/request_models.py
@@ -10,8 +10,8 @@ from pydantic.types import (
     StringConstraints,
 )
 
+from aeonlib.models import Window
 from aeonlib.ocs.lco.instruments import LCO_INSTRUMENTS
-from aeonlib.types import Time
 
 
 class Location(BaseModel):
@@ -25,14 +25,6 @@ class Location(BaseModel):
     enclosure: str | None = None
     telescope: str | None = None
     telescope_class: str
-
-
-class Window(BaseModel):
-    """Request level window configuration"""
-
-    model_config = ConfigDict(validate_assignment=True)
-    start: Time | datetime | None = None
-    end: Time | datetime
 
 
 class Cadence(BaseModel):

--- a/tests/eso/test_models.py
+++ b/tests/eso/test_models.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+import pytest
+from astropy.time import Time
+
+from aeonlib.eso.models import AbsoluteTimeConstraint
+from aeonlib.models import Window
+
+
+def test_constraints_from_window():
+    window = Window(
+        start=Time(60775.0, scale="utc", format="mjd"),
+        end=Time(60776.0, scale="utc", format="mjd"),
+    )
+
+    abs_constraint = AbsoluteTimeConstraint.from_window(window)
+
+    assert abs_constraint.start == datetime(2025, 4, 10, 0, 0)
+    assert abs_constraint.end == datetime(2025, 4, 11, 0, 0)
+
+
+def test_constraints_from_window_must_enter_start():
+    with pytest.raises(ValueError):
+        AbsoluteTimeConstraint.from_window(
+            Window(start=None, end=Time(60776.0, scale="utc", format="mjd"))
+        )

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -4,13 +4,48 @@ from aeonlib.eso.facility import EsoFacility
 
 pytestmark = pytest.mark.online
 
+# ID from ESO p2 docs: https://www.eso.org/copdemo/apidoc/index.html
+ESO_TUTORIAL_CONTAINER_ID = 1538878
+
 
 @pytest.mark.side_effect
 def test_create_folder():
     facility = EsoFacility()
-    # ID from ESO p2 docs: https://www.eso.org/copdemo/apidoc/index.html
-    run_container_id = 1538878
-    container = facility.create_folder(run_container_id, "AEONlib Unit Test")
-    assert container.name == "AEONlib Unit Test"
-    assert container.parent_container_id == run_container_id
-    assert container.run_id
+    folder = facility.create_folder(
+        ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_create_folder"
+    )
+    assert folder.name == "AEONlib.test_create_folder"
+    assert folder.parent_container_id == ESO_TUTORIAL_CONTAINER_ID
+    assert folder.container_id
+    facility.delete_container(folder)
+
+
+@pytest.mark.side_effect
+def test_create_ob():
+    facility = EsoFacility()
+    folder = facility.create_folder(ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_create_ob")
+    ob = facility.create_ob(folder, "AEONLIB.test_create_ob.ob")
+    assert ob.ob_id
+    assert ob.name == "AEONLIB.test_create_ob.ob"
+    assert ob.item_type == "OB"
+    facility.delete_ob(ob)
+    # Need to refresh the container
+    folder = facility.get_container(folder.container_id)
+    facility.delete_container(folder)
+
+
+@pytest.mark.side_effect
+def test_save_ob():
+    facility = EsoFacility()
+    folder = facility.create_folder(ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_save_ob")
+    ob = facility.create_ob(folder, "AEONLIB.test_save_ob.ob")
+    ob.name = "AEONlib.test_save_ob.ob-MODIFIED"
+    ob.target.name = "m51"
+    new_ob = facility.save_ob(ob)
+    assert new_ob.ob_id == ob.ob_id
+    assert new_ob.name == ob.name
+    assert new_ob.target.name == ob.target.name
+    facility.delete_ob(new_ob)
+    # Need to refresh the container
+    folder = facility.get_container(folder.container_id)
+    facility.delete_container(folder)

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -1,0 +1,16 @@
+import pytest
+
+from aeonlib.eso.facility import EsoFacility
+
+pytestmark = pytest.mark.online
+
+
+@pytest.mark.side_effect
+def test_create_folder():
+    facility = EsoFacility()
+    # ID from ESO p2 docs: https://www.eso.org/copdemo/apidoc/index.html
+    run_container_id = 1538878
+    container = facility.create_folder(run_container_id, "AEONlib Unit Test")
+    assert container.name == "AEONlib Unit Test"
+    assert container.parent_container_id == run_container_id
+    assert container.run_id

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -68,3 +68,36 @@ def test_create_template():
     # Need to refresh the container
     folder = facility.get_container(folder.container_id)
     facility.delete_container(folder)
+
+
+@pytest.mark.side_effect
+def test_update_template_params():
+    facility = EsoFacility()
+    folder = facility.create_folder(
+        ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_update_template_params"
+    )
+    ob = facility.create_ob(folder, "AEONLIB.test_update_template_params.ob")
+    template = facility.create_template(ob, "UVES_blue_acq_slit")
+    # Check initial rotator mode is not SKY
+    assert not any(
+        p.get("name") == "INS.DROT.MODE" and p.get("value") == "SKY"
+        for p in template.parameters
+    )
+    new_params = {
+        "TEL.GS1.ALPHA": "11:22:33.000",
+        "INS.DROT.MODE": "SKY",
+        "INS.ADC.MODE": "AUTO",
+    }
+    template = facility.update_template_params(ob, template, new_params)
+    # Check updated rotator mode is SKY
+    assert any(
+        p.get("name") == "INS.DROT.MODE" and p.get("value") == "SKY"
+        for p in template.parameters
+    )
+    facility.delete_template(ob, template)
+    # Need to refresh observation block
+    ob = facility.get_ob(ob.ob_id)
+    facility.delete_ob(ob)
+    # Need to refresh the container
+    folder = facility.get_container(folder.container_id)
+    facility.delete_container(folder)

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -1,5 +1,5 @@
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from io import BytesIO
 
 import pytest
@@ -154,8 +154,8 @@ def test_save_sidereal_time_constraints():
     sidereal_constraints = SiderealTimeConstraints(
         constraints=[
             SiderealTimeConstraint(
-                start=datetime.now().strftime("%H:%M"),
-                end=(datetime.now() + timedelta(hours=1)).strftime("%H:%M"),
+                start=time(2, 0),
+                end=time(12, 0),
             )
         ]
     )

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -49,3 +49,22 @@ def test_save_ob():
     # Need to refresh the container
     folder = facility.get_container(folder.container_id)
     facility.delete_container(folder)
+
+
+@pytest.mark.side_effect
+def test_create_template():
+    facility = EsoFacility()
+    folder = facility.create_folder(
+        ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_create_template"
+    )
+    ob = facility.create_ob(folder, "AEONLIB.test_create_template.ob")
+    template = facility.create_template(ob, "UVES_blue_acq_slit")
+    assert template.template_id
+    assert len(template.parameters)
+    facility.delete_template(ob, template)
+    # Need to refresh observation block
+    ob = facility.get_ob(ob.ob_id)
+    facility.delete_ob(ob)
+    # Need to refresh the container
+    folder = facility.get_container(folder.container_id)
+    facility.delete_container(folder)

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -6,6 +6,7 @@ from aeonlib.eso.facility import EsoFacility
 from aeonlib.eso.models import (
     AbsoluteTimeConstraint,
     AbsoluteTimeConstraints,
+    Ephemeris,
     SiderealTimeConstraint,
     SiderealTimeConstraints,
 )
@@ -167,6 +168,53 @@ def test_save_sidereal_time_constraints():
         new_sidereal_constraints.constraints[0].end
         == sidereal_constraints.constraints[0].end
     )
+    facility.delete_ob(ob)
+    # Need to refresh the container
+    folder = facility.get_container(folder.container_id)
+    facility.delete_container(folder)
+
+
+@pytest.mark.skip(reason="Errors with 'Ephemeris file must have at least two records.'")
+@pytest.mark.side_effect
+def test_save_ephemeris():
+    ephemeris_text = """    PAF.HDR.START,            # Start of PAF Header
+    PAF.TYPE                  "Instrument Setup", # Type of PAF
+    PAF.ID                    "", # ID for PAF
+    PAF.NAME                  "{PAFNAME}",# Name of PAF
+    PAF.DESC                  "Ephemeris / Eproc-4.3, 2025-04-30 20:54:26, IMCCE/OBSPM/CNRS"
+    PAF.DESC                  "Target body name: Ceres (1)"
+    PAF.DESC                  "Center body name: Earth {source: INPOP}"
+    PAF.DESC                  "Center-site name: Cerro Paranal"
+    PAF.DESC                  "Start time      : A.D. 2025-Apr-30 00:00:00.0000 UT"
+    PAF.DESC                  "Stop  time      : A.D. 2025-May-03 00:00:00.0000 UT"
+    PAF.DESC                  "Step-size       : 1.0  hours"
+    PAF.DESC                  "Target pole/equ : IAU {East-longitude -}"
+    PAF.DESC                  "Target radii    : 424.20 x 424.20 x 424.20 km {Equator, meridian, pole}"
+    PAF.DESC                  "Atmos refraction: NO (AIRLESS)"
+    PAF.CRTE.NAME             "Eproc.ephemcc", # Name of creator
+    PAF.HDR.END,              # End of PAF Header
+    # Ephem cuts: AM = 2.60, Sun elevation = 0.00 deg.
+    #------------------------------------------------------------------------------
+    #                              Date & Time (UT)             JD              RA (J2000)     Dec (J2000)    dRA ("/s)   dDEC ("/s)   V-mag  Slit PA
+    #------------------------------------------------------------------------------
+    INS.EPHEM.RECORD          "2025-04-30T10:00:00.000, 60795.41666666666, 23 52 34.5819, -10 14 26.580, 0.01342419, 0.00461927, 9.2919, 0.000, *"
+    INS.EPHEM.RECORD          "2025-04-30T11:00:00.000, 60795.45833333334, 23 52 37.8514, -10 14 09.945, 0.01338837, 0.00462241, 9.2919, 0.000, *"
+    #------------------------------------------------------------------------------
+    INS.EPHEM.RECORD          "2025-05-01T10:00:00.000, 60796.41666666666, 23 53 53.4767, -10 07 46.780, 0.01337469, 0.00458595, 9.2913, 0.000, *"
+    INS.EPHEM.RECORD          "2025-05-01T11:00:00.000, 60796.45833333334, 23 53 56.7330, -10 07 30.265, 0.01333904, 0.00458910, 9.2913, 0.000, *"
+    #------------------------------------------------------------------------------
+    INS.EPHEM.RECORD          "2025-05-02T10:00:00.000, 60797.41666666666, 23 55 12.0632, -10 01 09.917, 0.01332444, 0.00455202, 9.2906, 0.000, *"
+    INS.EPHEM.RECORD          "2025-05-02T11:00:00.000, 60797.45833333334, 23 55 15.3062, -10 00 53.524, 0.01328897, 0.00455516, 9.2905, 0.000, *"
+    #------------------------------------------------------------------------------"""
+    facility = EsoFacility()
+    folder = facility.create_folder(
+        ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_save_ephemeris"
+    )
+    ob = facility.create_ob(folder, "AEONLIB.test_save_ephemeris.ob")
+    ephemeris = Ephemeris(text=ephemeris_text)
+    new_ephemeris = facility.save_ephemeris(ob, ephemeris)
+    assert new_ephemeris.text == ephemeris.text
+    facility.delete_ephemeris(ob, new_ephemeris)
     facility.delete_ob(ob)
     # Need to refresh the container
     folder = facility.get_container(folder.container_id)

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -1,4 +1,6 @@
+import base64
 from datetime import datetime, timedelta
+from io import BytesIO
 
 import pytest
 
@@ -215,6 +217,27 @@ def test_save_ephemeris():
     new_ephemeris = facility.save_ephemeris(ob, ephemeris)
     assert new_ephemeris.text == ephemeris.text
     facility.delete_ephemeris(ob, new_ephemeris)
+    facility.delete_ob(ob)
+    # Need to refresh the container
+    folder = facility.get_container(folder.container_id)
+    facility.delete_container(folder)
+
+
+@pytest.mark.side_effect
+def test_add_finding_chart():
+    # ESO validates that the chart is a valid jpeg. This is the smallest
+    # possible jpeg image I could find.
+    teeny_jpg = "/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k="
+    teeny_jpg_bytes = base64.b64decode(teeny_jpg)
+    facility = EsoFacility()
+    folder = facility.create_folder(
+        ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_add_finding_chart"
+    )
+    ob = facility.create_ob(folder, "AEONLIB.test_add_finding_chart.ob")
+    facility.add_finding_chart(ob, chart=BytesIO(teeny_jpg_bytes), name="test")
+    chart_names = facility.get_finding_chart_names(ob)
+    assert len(chart_names) == 1
+    facility.delete_finding_chart(ob, 1)
     facility.delete_ob(ob)
     # Need to refresh the container
     folder = facility.get_container(folder.container_id)

--- a/tests/eso/test_online.py
+++ b/tests/eso/test_online.py
@@ -3,7 +3,12 @@ from datetime import datetime, timedelta
 import pytest
 
 from aeonlib.eso.facility import EsoFacility
-from aeonlib.eso.models import AbsoluteTimeConstraint
+from aeonlib.eso.models import (
+    AbsoluteTimeConstraint,
+    AbsoluteTimeConstraints,
+    SiderealTimeConstraint,
+    SiderealTimeConstraints,
+)
 
 pytestmark = pytest.mark.online
 
@@ -113,12 +118,12 @@ def test_save_absolute_time_constraints():
         ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_save_abs_time_con"
     )
     ob = facility.create_ob(folder, "AEONLIB.test_save_abs_time_con.ob")
-    abs_constraints = facility.get_absolute_time_constraints(ob)
-    assert len(abs_constraints.constraints) == 0
-    abs_constraints.constraints.append(
-        AbsoluteTimeConstraint(
-            start=datetime.now(), end=datetime.now() + timedelta(days=30)
-        )
+    abs_constraints = AbsoluteTimeConstraints(
+        constraints=[
+            AbsoluteTimeConstraint(
+                start=datetime.now(), end=datetime.now() + timedelta(days=30)
+            )
+        ]
     )
     new_abs_constraints = facility.save_absolute_time_constraints(ob, abs_constraints)
     # Saving loses some precision on time, so just compare the date for this test
@@ -129,6 +134,38 @@ def test_save_absolute_time_constraints():
     assert (
         new_abs_constraints.constraints[0].end.date()
         == abs_constraints.constraints[0].end.date()
+    )
+    facility.delete_ob(ob)
+    # Need to refresh the container
+    folder = facility.get_container(folder.container_id)
+    facility.delete_container(folder)
+
+
+@pytest.mark.side_effect
+def test_save_sidereal_time_constraints():
+    facility = EsoFacility()
+    folder = facility.create_folder(
+        ESO_TUTORIAL_CONTAINER_ID, "AEONlib.test_save_sidereal_time_con"
+    )
+    ob = facility.create_ob(folder, "AEONLIB.test_save_sidereal_time_con.ob")
+    sidereal_constraints = SiderealTimeConstraints(
+        constraints=[
+            SiderealTimeConstraint(
+                start=datetime.now().strftime("%H:%M"),
+                end=(datetime.now() + timedelta(hours=1)).strftime("%H:%M"),
+            )
+        ]
+    )
+    new_sidereal_constraints = facility.save_sidereal_time_constraints(
+        ob, sidereal_constraints
+    )
+    assert (
+        new_sidereal_constraints.constraints[0].start
+        == sidereal_constraints.constraints[0].start
+    )
+    assert (
+        new_sidereal_constraints.constraints[0].end
+        == sidereal_constraints.constraints[0].end
     )
     facility.delete_ob(ob)
     # Need to refresh the container

--- a/tests/ocs/lco_requests.py
+++ b/tests/ocs/lco_requests.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 
+from aeonlib.models import Window
 from aeonlib.ocs import (
     Constraints,
     Location,
     Request,
     RequestGroup,
     SiderealTarget,
-    Window,
 )
 from aeonlib.ocs.lco.instruments import (
     Lco1M0ScicamSinistro,

--- a/tests/ocs/test_models.py
+++ b/tests/ocs/test_models.py
@@ -3,13 +3,13 @@ from datetime import datetime, timedelta
 import pytest
 from pydantic import ValidationError
 
+from aeonlib.models import Window
 from aeonlib.ocs import (
     Constraints,
     Location,
     Request,
     RequestGroup,
     SiderealTarget,
-    Window,
 )
 from aeonlib.ocs.lco.instruments import Lco1M0ScicamSinistro
 

--- a/tests/ocs/test_online.py
+++ b/tests/ocs/test_online.py
@@ -38,6 +38,7 @@ def test_valid_requests(facility: LcoFacility, request_group: RequestGroup):
     assert valid
 
 
+@pytest.mark.side_effect
 def test_submit_request(facility: LcoFacility):
     request_group_in = LCO_REQUESTS["lco_1m0_scicam_sinistro"]
     request_group_out = facility.submit_request_group(request_group_in)

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,9 @@ codegen = [
 dev = [
     { name = "pytest" },
 ]
+eso = [
+    { name = "p2api" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -36,6 +39,7 @@ codegen = [
     { name = "textcase", specifier = ">=0.2.1" },
 ]
 dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+eso = [{ name = "p2api", specifier = ">=1.0.10" }]
 
 [[package]]
 name = "annotated-types"
@@ -108,12 +112,101 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload_time = "2024-09-04T20:45:21.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload_time = "2024-09-04T20:44:15.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload_time = "2024-09-04T20:44:17.188Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload_time = "2024-09-04T20:44:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload_time = "2024-09-04T20:44:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload_time = "2024-09-04T20:44:21.673Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload_time = "2024-09-04T20:44:23.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload_time = "2024-09-04T20:44:24.757Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload_time = "2024-09-04T20:44:32.01Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload_time = "2024-09-04T20:44:33.606Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload_time = "2024-09-04T20:44:35.191Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload_time = "2024-09-04T20:44:36.743Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload_time = "2024-09-04T20:44:38.492Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload_time = "2024-09-04T20:44:40.046Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload_time = "2024-09-04T20:44:41.616Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188, upload_time = "2024-12-24T18:12:35.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105, upload_time = "2024-12-24T18:10:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404, upload_time = "2024-12-24T18:10:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423, upload_time = "2024-12-24T18:10:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184, upload_time = "2024-12-24T18:10:47.898Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268, upload_time = "2024-12-24T18:10:50.589Z" },
+    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601, upload_time = "2024-12-24T18:10:52.541Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098, upload_time = "2024-12-24T18:10:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520, upload_time = "2024-12-24T18:10:55.048Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852, upload_time = "2024-12-24T18:10:57.647Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488, upload_time = "2024-12-24T18:10:59.43Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192, upload_time = "2024-12-24T18:11:00.676Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550, upload_time = "2024-12-24T18:11:01.952Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785, upload_time = "2024-12-24T18:11:03.142Z" },
+    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698, upload_time = "2024-12-24T18:11:05.834Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162, upload_time = "2024-12-24T18:11:07.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263, upload_time = "2024-12-24T18:11:08.374Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966, upload_time = "2024-12-24T18:11:09.831Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992, upload_time = "2024-12-24T18:11:12.03Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162, upload_time = "2024-12-24T18:11:13.372Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972, upload_time = "2024-12-24T18:11:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095, upload_time = "2024-12-24T18:11:17.672Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668, upload_time = "2024-12-24T18:11:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073, upload_time = "2024-12-24T18:11:21.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732, upload_time = "2024-12-24T18:11:22.774Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391, upload_time = "2024-12-24T18:11:24.139Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702, upload_time = "2024-12-24T18:11:26.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767, upload_time = "2024-12-24T18:12:32.852Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload_time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload_time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "44.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/25/4ce80c78963834b8a9fd1cc1266be5ed8d1840785c0f2e1b73b8d128d505/cryptography-44.0.2.tar.gz", hash = "sha256:c63454aa261a0cf0c5b4718349629793e9e634993538db841165b3df74f37ec0", size = 710807, upload_time = "2025-03-02T00:01:37.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/ec/7ea7c1e4c8fc8329506b46c6c4a52e2f20318425d48e0fe597977c71dbce/cryptography-44.0.2-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29ecec49f3ba3f3849362854b7253a9f59799e3763b0c9d0826259a88efa02f1", size = 3952350, upload_time = "2025-03-02T00:00:09.537Z" },
+    { url = "https://files.pythonhosted.org/packages/27/61/72e3afdb3c5ac510330feba4fc1faa0fe62e070592d6ad00c40bb69165e5/cryptography-44.0.2-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc821e161ae88bfe8088d11bb39caf2916562e0a2dc7b6d56714a48b784ef0bb", size = 4166572, upload_time = "2025-03-02T00:00:12.03Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e4/ba680f0b35ed4a07d87f9e98f3ebccb05091f3bf6b5a478b943253b3bbd5/cryptography-44.0.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3c00b6b757b32ce0f62c574b78b939afab9eecaf597c4d624caca4f9e71e7843", size = 3958124, upload_time = "2025-03-02T00:00:14.518Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e8/44ae3e68c8b6d1cbc59040288056df2ad7f7f03bbcaca6b503c737ab8e73/cryptography-44.0.2-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7bdcd82189759aba3816d1f729ce42ffded1ac304c151d0a8e89b9996ab863d5", size = 3678122, upload_time = "2025-03-02T00:00:17.212Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7b/664ea5e0d1eab511a10e480baf1c5d3e681c7d91718f60e149cec09edf01/cryptography-44.0.2-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4973da6ca3db4405c54cd0b26d328be54c7747e89e284fcff166132eb7bccc9c", size = 4191831, upload_time = "2025-03-02T00:00:19.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/07/79554a9c40eb11345e1861f46f845fa71c9e25bf66d132e123d9feb8e7f9/cryptography-44.0.2-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4e389622b6927d8133f314949a9812972711a111d577a5d1f4bee5e58736b80a", size = 3960583, upload_time = "2025-03-02T00:00:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6d/858e356a49a4f0b591bd6789d821427de18432212e137290b6d8a817e9bf/cryptography-44.0.2-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308", size = 4191753, upload_time = "2025-03-02T00:00:25.038Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/80/62df41ba4916067fa6b125aa8c14d7e9181773f0d5d0bd4dcef580d8b7c6/cryptography-44.0.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1bc312dfb7a6e5d66082c87c34c8a62176e684b6fe3d90fcfe1568de675e6688", size = 4079550, upload_time = "2025-03-02T00:00:26.929Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cd/2558cc08f7b1bb40683f99ff4327f8dcfc7de3affc669e9065e14824511b/cryptography-44.0.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b721b8b4d948b218c88cb8c45a01793483821e709afe5f622861fc6182b20a7", size = 4298367, upload_time = "2025-03-02T00:00:28.735Z" },
+    { url = "https://files.pythonhosted.org/packages/06/88/638865be7198a84a7713950b1db7343391c6066a20e614f8fa286eb178ed/cryptography-44.0.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81276f0ea79a208d961c433a947029e1a15948966658cf6710bbabb60fcc2639", size = 3951919, upload_time = "2025-03-02T00:00:38.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fc/99fe639bcdf58561dfad1faa8a7369d1dc13f20acd78371bb97a01613585/cryptography-44.0.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a1e657c0f4ea2a23304ee3f964db058c9e9e635cc7019c4aa21c330755ef6fd", size = 4167812, upload_time = "2025-03-02T00:00:42.934Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7b/aafe60210ec93d5d7f552592a28192e51d3c6b6be449e7fd0a91399b5d07/cryptography-44.0.2-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6210c05941994290f3f7f175a4a57dbbb2afd9273657614c506d5976db061181", size = 3958571, upload_time = "2025-03-02T00:00:46.026Z" },
+    { url = "https://files.pythonhosted.org/packages/16/32/051f7ce79ad5a6ef5e26a92b37f172ee2d6e1cce09931646eef8de1e9827/cryptography-44.0.2-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1c3572526997b36f245a96a2b1713bf79ce99b271bbcf084beb6b9b075f29ea", size = 3679832, upload_time = "2025-03-02T00:00:48.647Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2b/999b2a1e1ba2206f2d3bca267d68f350beb2b048a41ea827e08ce7260098/cryptography-44.0.2-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b042d2a275c8cee83a4b7ae30c45a15e6a4baa65a179a0ec2d78ebb90e4f6699", size = 4193719, upload_time = "2025-03-02T00:00:51.397Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/430e56e39a1356e8e8f10f723211a0e256e11895ef1a135f30d7d40f2540/cryptography-44.0.2-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:d03806036b4f89e3b13b6218fefea8d5312e450935b1a2d55f0524e2ed7c59d9", size = 3960852, upload_time = "2025-03-02T00:00:53.317Z" },
+    { url = "https://files.pythonhosted.org/packages/89/33/c1cf182c152e1d262cac56850939530c05ca6c8d149aa0dcee490b417e99/cryptography-44.0.2-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c7362add18b416b69d58c910caa217f980c5ef39b23a38a0880dfd87bdf8cd23", size = 4193906, upload_time = "2025-03-02T00:00:56.49Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/99/87cf26d4f125380dc674233971069bc28d19b07f7755b29861570e513650/cryptography-44.0.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8cadc6e3b5a1f144a039ea08a0bdb03a2a92e19c46be3285123d32029f40a922", size = 4081572, upload_time = "2025-03-02T00:00:59.995Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/6a3e0391957cc0c5f84aef9fbdd763035f2b52e998a53f99345e3ac69312/cryptography-44.0.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6f101b1f780f7fc613d040ca4bdf835c6ef3b00e9bd7125a4255ec574c7916e4", size = 4298631, upload_time = "2025-03-02T00:01:01.623Z" },
 ]
 
 [[package]]
@@ -172,6 +265,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload_time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload_time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912, upload_time = "2024-08-20T03:39:27.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825, upload_time = "2024-08-20T03:39:25.966Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d", size = 19159, upload_time = "2024-09-27T19:47:09.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl", hash = "sha256:ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649", size = 10187, upload_time = "2024-09-27T19:47:07.14Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload_time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload_time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -181,6 +316,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload_time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload_time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750, upload_time = "2024-12-25T15:26:45.782Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085, upload_time = "2024-12-25T15:26:44.377Z" },
 ]
 
 [[package]]
@@ -222,6 +374,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload_time = "2025-04-22T14:17:41.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload_time = "2025-04-22T14:17:40.49Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -260,6 +421,19 @@ wheels = [
 ]
 
 [[package]]
+name = "p2api"
+version = "1.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "keyring" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/94/96ece6cf22552578a16f82ccedabc1d067f65ba871cfec60324a2eb51d12/p2api-1.0.10.tar.gz", hash = "sha256:9d9d41d978fb5143c9eb1e7119bd8bd7ff1c0f74b267d2fef425e59c717b35ef", size = 25017, upload_time = "2024-09-12T12:56:51.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a3/07ff4a0be52675076fea31558ed4c4e880887df606bcdd395ac8b2802298/p2api-1.0.10-py2.py3-none-any.whl", hash = "sha256:0d1d1edfbbc9202174147fa34117522db6c27af4b4d3e86adad7458f2df6965b", size = 26400, upload_time = "2024-09-12T12:56:49.809Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -275,6 +449,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload_time = "2024-04-20T21:34:42.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload_time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload_time = "2024-03-30T13:22:22.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload_time = "2024-03-30T13:22:20.476Z" },
 ]
 
 [[package]]
@@ -391,6 +574,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload_time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload_time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -414,6 +606,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload_time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload_time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload_time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload_time = "2024-05-29T15:37:49.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload_time = "2024-05-29T15:37:47.027Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload_time = "2022-08-13T16:22:46.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload_time = "2022-08-13T16:22:44.457Z" },
 ]
 
 [[package]]
@@ -453,4 +673,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222, upload_time = "2025-02-25T17:27:59.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125, upload_time = "2025-02-25T17:27:57.754Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload_time = "2025-04-10T15:23:39.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload_time = "2025-04-10T15:23:37.377Z" },
 ]


### PR DESCRIPTION
This PR includes a model and ESOFacility that can be used to create Phase 2 Observation Blocks. The API follows that of the ESO client library closely, hiding a few details like tracking version #s between objects and the ability to use astropy.Time objects in the AbsoluteTimeConstraints models, for example. 

It also abstracts away the need to pass real file names to upload finder images and ephemeride files, any file like object should work.

Follow up PRs should enable constructing the Observation Block from a general Target model, and more flexible types for various fields.

The online tests follow the phase 2 tutorial closely: https://www.eso.org/sci/observing/phase2/p2intro/Phase2API/api--python-programming-tutorial.html 

Anyone who has used the ESO client library should find the AEONlib api familiar, and in fact can access the underlying eso api module easily if necessary.