### PR TITLE
20 common target models

### DIFF
--- a/codegen/lco/templates/instruments.jinja
+++ b/codegen/lco/templates/instruments.jinja
@@ -4,7 +4,8 @@ from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
 from pydantic.types import NonNegativeInt, PositiveInt
 
-from aeonlib.ocs.target_models import Constraints, SiderealTarget, NonSiderealTarget
+from aeonlib.models import SiderealTarget, NonSiderealTarget
+from aeonlib.ocs.target_models import Constraints
 from aeonlib.ocs.config_models import Roi
 
 

--- a/src/aeonlib/eso/models.py
+++ b/src/aeonlib/eso/models.py
@@ -1,10 +1,11 @@
 from datetime import datetime, time
 from typing import Any, Self
 
+from astropy.coordinates import Angle
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
-from aeonlib.models import Window
+from aeonlib.models import SiderealTarget, Window
 
 
 class EsoModel(BaseModel):
@@ -40,6 +41,20 @@ class Target(EsoModel):
     proper_motion_dec: float
     proper_motion_ra: float
     ra: str
+
+    def use_sidereal_target(self, st: SiderealTarget) -> None:
+        """Fills in the target fields of an observation block
+        using an general Aeonlib SiderealTarget object
+        """
+        # Format angles the way ESO wants them.
+        assert isinstance(st.ra, Angle)
+        assert isinstance(st.dec, Angle)
+        self.ra = st.ra.to_string(sep=":", precision=3)
+        self.dec = st.dec.to_string(sep=":", precision=3)
+        self.epoch = st.epoch
+        self.name = st.name
+        self.proper_motion_dec = st.proper_motion_dec
+        self.proper_motion_ra = st.proper_motion_ra
 
 
 class ObservationBlock(EsoModel):

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -2,8 +2,6 @@
 Models shared between facilities.
 """
 
-from datetime import datetime
-
 from pydantic import BaseModel, ConfigDict
 
 from aeonlib.types import Time
@@ -13,5 +11,5 @@ class Window(BaseModel):
     """A general time window"""
 
     model_config = ConfigDict(validate_assignment=True)
-    start: Time | datetime | None = None
-    end: Time | datetime
+    start: Time | None = None
+    end: Time

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -20,15 +20,15 @@ class SiderealTarget(BaseModel):
     """The name of this Target"""
     type: Literal["ICRS", "HOUR_ANGLE", "ALTAZ"]
     """The type of this Target"""
-    hour_angle: Annotated[float, Ge(-180), Le(180)] | None = None
+    hour_angle: Angle | None = None
     """Hour angle of this Target in decimal degrees"""
     ra: Angle
     """Right ascension in decimal degrees"""
     dec: Angle
     """Declination in decimal degrees"""
-    altitude: Annotated[float, NonNegativeFloat, Le(90)] | None = None
+    altitude: Angle | None = None
     """Altitude of this Target in decimal degrees"""
-    azimuth: Annotated[float, NonNegativeFloat, Le(360)] | None = None
+    azimuth: Angle | None = None
     """Azimuth of this Target in decimal degrees east of North"""
     proper_motion_ra: Annotated[float, Le(20000.0)] = 0
     """Right ascension proper motion of the Target in mas/year. Defaults to 0."""
@@ -58,17 +58,17 @@ class NonSiderealTarget(BaseModel):
     """The Target scheme to use"""
     epochofel: Annotated[float, Ge(10_000), Le(100_000)]
     """The epoch of the orbital elements (MJD)"""
-    orbinc: Annotated[float, NonNegativeFloat, Le(180.0)]
+    orbinc: Angle
     """Orbital inclination (angle in degrees)"""
-    longascnode: Annotated[float, NonNegativeFloat, Le(360.0)]
+    longascnode: Angle
     """Longitude of ascending node (angle in degrees)"""
-    argofperih: Annotated[float, NonNegativeFloat, Le(360.0)]
+    argofperih: Angle
     """Argument of perihelion (angle in degrees)"""
     eccentricity: NonNegativeFloat
     """Eccentricity of the orbit"""
     meandist: Annotated[float, NonNegativeFloat]
     """Semi-major axis (AU)"""  # Not Comet
-    meananom: Annotated[float, NonNegativeFloat, Le(360.0)]
+    meananom: Angle
     """Mean anomaly (angle in degrees)"""
     perihdist: Annotated[float, NonNegativeFloat] | None = None
     """Perihelion distance (AU)"""  # Comet Only
@@ -76,9 +76,9 @@ class NonSiderealTarget(BaseModel):
     """Epoch of perihelion (MJD)"""  # Comet Only
     dailymot: float | None = None
     """Daily motion (angle in degrees)"""  # Major Planet Only
-    altitude: Annotated[float, NonNegativeFloat, Le(90)] | None = None
+    altitude: Angle | None = None
     """Altitude of this Target in decimal degrees"""  # Satellite Only
-    azimuth: Annotated[float, NonNegativeFloat, Le(360)] | None = None
+    azimuth: Angle | None = None
     """Azimuth of this Target in decimal degrees east of North"""  # Satellite Only
     diff_altitude_rate: float | None = None
     """Differential altitude rate (arcsec/s)"""  # Satellite Only
@@ -90,9 +90,9 @@ class NonSiderealTarget(BaseModel):
     """Differential altitude acceleration (arcsec/s^2)"""  # Satellite Only
     diff_azimuth_acceleration: float | None = None
     """Differential azimuth acceleration (arcsec/s^2)"""  # Satellite Only
-    meanlong: float | None = None
+    meanlong: Angle | None = None
     """Mean longitude (angle in degrees)"""  # No idea what this is.
-    longofperih: Annotated[float, NonNegativeFloat, Le(360.0)] | None = None
+    longofperih: Angle | None = None
     """Longitude of perihelion (angle in degrees)"""  # No idea what this is.
     extra_params: dict[Any, Any] = {}
 

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -2,9 +2,99 @@
 Models shared between facilities.
 """
 
+from typing import Annotated, Any, Literal
+
+from annotated_types import Ge, Le
 from pydantic import BaseModel, ConfigDict
+from pydantic.types import (
+    NonNegativeFloat,
+    StringConstraints,
+)
 
 from aeonlib.types import Time
+
+
+class SiderealTarget(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+    name: Annotated[str, StringConstraints(max_length=50)] = "string"
+    """The name of this Target"""
+    type: Literal["ICRS", "HOUR_ANGLE", "ALTAZ"]
+    """The type of this Target"""
+    hour_angle: Annotated[float, Ge(-180), Le(180)] | None = None
+    """Hour angle of this Target in decimal degrees"""
+    ra: Annotated[float, NonNegativeFloat, Le(360.0)]
+    """Right ascension in decimal degrees"""
+    dec: Annotated[float, Ge(-90), Le(90)]
+    """Declination in decimal degrees"""
+    altitude: Annotated[float, NonNegativeFloat, Le(90)] | None = None
+    """Altitude of this Target in decimal degrees"""
+    azimuth: Annotated[float, NonNegativeFloat, Le(360)] | None = None
+    """Azimuth of this Target in decimal degrees east of North"""
+    proper_motion_ra: Annotated[float, Le(20000.0)] = 0
+    """Right ascension proper motion of the Target in mas/year. Defaults to 0."""
+    proper_motion_dec: Annotated[float, Le(20000.0)] = 0
+    """Declination proper motion of the Target in mas/year. Defaults to 0."""
+    epoch: Annotated[int, Le(2100)] = 2000
+    """Epoch of coordinates in Julian Years. Defaults to 2000."""
+    parallax: Annotated[float, Le(2000)] = 0
+    """Parallax of the Target in mas, max 2000. Defaults to 0."""
+
+
+class NonSiderealTarget(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+    name: Annotated[str, StringConstraints(max_length=50)] = "string"
+    """The name of this Target"""
+    type: Literal["ORBITAL_ELEMENTS", "SATELLITE"]
+    """The type of this Target TODO: Where does HOUR_ANGLE make sense?"""
+    scheme: Literal[
+        "ASA_MAJOR_PLANET",
+        "ASA_MINOR_PLANET",
+        "ASA_COMET",
+        "JPL_MAJOR_PLANET",
+        "JPL_MINOR_PLANET",
+        "MPC_MINOR_PLANET",
+        "MPC_COMET",
+    ]
+    """The Target scheme to use"""
+    epochofel: Annotated[float, Ge(10_000), Le(100_000)]
+    """The epoch of the orbital elements (MJD)"""
+    orbinc: Annotated[float, NonNegativeFloat, Le(180.0)]
+    """Orbital inclination (angle in degrees)"""
+    longascnode: Annotated[float, NonNegativeFloat, Le(360.0)]
+    """Longitude of ascending node (angle in degrees)"""
+    argofperih: Annotated[float, NonNegativeFloat, Le(360.0)]
+    """Argument of perihelion (angle in degrees)"""
+    eccentricity: NonNegativeFloat
+    """Eccentricity of the orbit"""
+    meandist: Annotated[float, NonNegativeFloat]
+    """Semi-major axis (AU)"""  # Not Comet
+    meananom: Annotated[float, NonNegativeFloat, Le(360.0)]
+    """Mean anomaly (angle in degrees)"""
+    perihdist: Annotated[float, NonNegativeFloat] | None = None
+    """Perihelion distance (AU)"""  # Comet Only
+    epochofperih: Annotated[float, Le(240_000), Le(100_000)] | None = None
+    """Epoch of perihelion (MJD)"""  # Comet Only
+    dailymot: float | None = None
+    """Daily motion (angle in degrees)"""  # Major Planet Only
+    altitude: Annotated[float, NonNegativeFloat, Le(90)] | None = None
+    """Altitude of this Target in decimal degrees"""  # Satellite Only
+    azimuth: Annotated[float, NonNegativeFloat, Le(360)] | None = None
+    """Azimuth of this Target in decimal degrees east of North"""  # Satellite Only
+    diff_altitude_rate: float | None = None
+    """Differential altitude rate (arcsec/s)"""  # Satellite Only
+    diff_azimuth_rate: float | None = None
+    """Differential azimuth rate (arcsec/s)"""  # Satellite Only
+    diff_epoch: float | None = None
+    """Reference time for non-sidereal motion (MJD)"""  # Satellite Only
+    diff_altitude_acceleration: float | None = None
+    """Differential altitude acceleration (arcsec/s^2)"""  # Satellite Only
+    diff_azimuth_acceleration: float | None = None
+    """Differential azimuth acceleration (arcsec/s^2)"""  # Satellite Only
+    meanlong: float | None = None
+    """Mean longitude (angle in degrees)"""  # No idea what this is.
+    longofperih: Annotated[float, NonNegativeFloat, Le(360.0)] | None = None
+    """Longitude of perihelion (angle in degrees)"""  # No idea what this is.
+    extra_params: dict[Any, Any] = {}
 
 
 class Window(BaseModel):

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -11,7 +11,7 @@ from pydantic.types import (
     StringConstraints,
 )
 
-from aeonlib.types import Time
+from aeonlib.types import Angle, Time
 
 
 class SiderealTarget(BaseModel):
@@ -22,9 +22,9 @@ class SiderealTarget(BaseModel):
     """The type of this Target"""
     hour_angle: Annotated[float, Ge(-180), Le(180)] | None = None
     """Hour angle of this Target in decimal degrees"""
-    ra: Annotated[float, NonNegativeFloat, Le(360.0)]
+    ra: Angle
     """Right ascension in decimal degrees"""
-    dec: Annotated[float, Ge(-90), Le(90)]
+    dec: Angle
     """Declination in decimal degrees"""
     altitude: Annotated[float, NonNegativeFloat, Le(90)] | None = None
     """Altitude of this Target in decimal degrees"""

--- a/src/aeonlib/ocs/__init__.py
+++ b/src/aeonlib/ocs/__init__.py
@@ -1,11 +1,9 @@
 from .request_models import Location, Request, RequestGroup
-from .target_models import Constraints, NonSiderealTarget, SiderealTarget
+from .target_models import Constraints
 
 __all__ = [
     "Location",
     "Request",
     "RequestGroup",
     "Constraints",
-    "SiderealTarget",
-    "NonSiderealTarget",
 ]

--- a/src/aeonlib/ocs/lco/instruments.py
+++ b/src/aeonlib/ocs/lco/instruments.py
@@ -4,7 +4,8 @@ from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
 from pydantic.types import NonNegativeInt, PositiveInt
 
-from aeonlib.ocs.target_models import Constraints, SiderealTarget, NonSiderealTarget
+from aeonlib.models import SiderealTarget, NonSiderealTarget
+from aeonlib.ocs.target_models import Constraints
 from aeonlib.ocs.config_models import Roi
 
 

--- a/src/aeonlib/ocs/target_models.py
+++ b/src/aeonlib/ocs/target_models.py
@@ -1,97 +1,11 @@
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
-from annotated_types import Ge, Le
+from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
 from pydantic.types import (
     NonNegativeFloat,
     PositiveFloat,
-    StringConstraints,
 )
-
-
-class SiderealTarget(BaseModel):
-    model_config = ConfigDict(validate_assignment=True)
-    name: Annotated[str, StringConstraints(max_length=50)] = "string"
-    """The name of this Target"""
-    type: Literal["ICRS", "HOUR_ANGLE", "ALTAZ"]
-    """The type of this Target"""
-    hour_angle: Annotated[float, Ge(-180), Le(180)] | None = None
-    """Hour angle of this Target in decimal degrees"""
-    ra: Annotated[float, NonNegativeFloat, Le(360.0)]
-    """Right ascension in decimal degrees"""
-    dec: Annotated[float, Ge(-90), Le(90)]
-    """Declination in decimal degrees"""
-    altitude: Annotated[float, NonNegativeFloat, Le(90)] | None = None
-    """Altitude of this Target in decimal degrees"""
-    azimuth: Annotated[float, NonNegativeFloat, Le(360)] | None = None
-    """Azimuth of this Target in decimal degrees east of North"""
-    proper_motion_ra: Annotated[float, Le(20000.0)] = 0
-    """Right ascension proper motion of the Target in mas/year. Defaults to 0."""
-    proper_motion_dec: Annotated[float, Le(20000.0)] = 0
-    """Declination proper motion of the Target in mas/year. Defaults to 0."""
-    epoch: Annotated[int, Le(2100)] = 2000
-    """Epoch of coordinates in Julian Years. Defaults to 2000."""
-    parallax: Annotated[float, Le(2000)] = 0
-    """Parallax of the Target in mas, max 2000. Defaults to 0."""
-
-
-
-class NonSiderealTarget(BaseModel):
-    model_config = ConfigDict(validate_assignment=True)
-    name: Annotated[str, StringConstraints(max_length=50)] = "string"
-    """The name of this Target"""
-    type: Literal["ORBITAL_ELEMENTS", "SATELLITE"]
-    """The type of this Target TODO: Where does HOUR_ANGLE make sense?"""
-    scheme: Literal[
-        "ASA_MAJOR_PLANET",
-        "ASA_MINOR_PLANET",
-        "ASA_COMET",
-        "JPL_MAJOR_PLANET",
-        "JPL_MINOR_PLANET",
-        "MPC_MINOR_PLANET",
-        "MPC_COMET",
-    ]
-    """The Target scheme to use"""
-    epochofel: Annotated[float, Ge(10_000), Le(100_000)]
-    """The epoch of the orbital elements (MJD)"""
-    orbinc: Annotated[float, NonNegativeFloat, Le(180.0)]
-    """Orbital inclination (angle in degrees)"""
-    longascnode: Annotated[float, NonNegativeFloat, Le(360.0)]
-    """Longitude of ascending node (angle in degrees)"""
-    argofperih: Annotated[float, NonNegativeFloat, Le(360.0)]
-    """Argument of perihelion (angle in degrees)"""
-    eccentricity: NonNegativeFloat
-    """Eccentricity of the orbit"""
-    meandist: Annotated[float, NonNegativeFloat]
-    """Semi-major axis (AU)""" # Not Comet
-    meananom: Annotated[float, NonNegativeFloat, Le(360.0)]
-    """Mean anomaly (angle in degrees)"""
-    perihdist: Annotated[float, NonNegativeFloat] | None = None
-    """Perihelion distance (AU)""" # Comet Only
-    epochofperih: Annotated[float, Le(240_000), Le(100_000)] | None = None
-    """Epoch of perihelion (MJD)""" # Comet Only
-    dailymot: float | None = None
-    """Daily motion (angle in degrees)""" # Major Planet Only
-    altitude: Annotated[float, NonNegativeFloat, Le(90)] | None = None
-    """Altitude of this Target in decimal degrees""" # Satellite Only
-    azimuth: Annotated[float, NonNegativeFloat, Le(360)] | None = None
-    """Azimuth of this Target in decimal degrees east of North""" # Satellite Only
-    diff_altitude_rate: float | None = None
-    """Differential altitude rate (arcsec/s)""" # Satellite Only
-    diff_azimuth_rate: float | None = None
-    """Differential azimuth rate (arcsec/s)""" # Satellite Only
-    diff_epoch: float | None = None
-    """Reference time for non-sidereal motion (MJD)""" # Satellite Only
-    diff_altitude_acceleration: float | None = None
-    """Differential altitude acceleration (arcsec/s^2)""" # Satellite Only
-    diff_azimuth_acceleration: float | None = None
-    """Differential azimuth acceleration (arcsec/s^2)""" # Satellite Only
-    meanlong: float | None = None
-    """Mean longitude (angle in degrees)""" # No idea what this is.
-    longofperih: Annotated[float, NonNegativeFloat, Le(360.0)] | None = None
-    """Longitude of perihelion (angle in degrees)"""  # No idea what this is.
-    extra_params: dict[Any, Any] = {}
-
 
 
 class Constraints(BaseModel):

--- a/tests/eso/test_models.py
+++ b/tests/eso/test_models.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
 import pytest
+from astropy.coordinates.earth import Angle
 from astropy.time import Time
 
-from aeonlib.eso.models import AbsoluteTimeConstraint
-from aeonlib.models import Window
+from aeonlib.eso.models import AbsoluteTimeConstraint, Target
+from aeonlib.models import SiderealTarget, Window
 
 
 def test_constraints_from_window():
@@ -24,3 +25,30 @@ def test_constraints_from_window_must_enter_start():
         AbsoluteTimeConstraint.from_window(
             Window(start=None, end=Time(60776.0, scale="utc", format="mjd"))
         )
+
+
+def test_eso_target_from_sidereal_target():
+    sidereal_target = SiderealTarget(
+        name="Test Target",
+        ra=Angle(24.5, unit="deg"),
+        dec=Angle(12.5, unit="deg"),
+        type="ICRS",
+    )
+
+    eso_target = Target(
+        dec="00:00:00.000",
+        differential_dec=0.0,
+        differential_ra=0.0,
+        epoch=2000.0,
+        equinox="J2000",
+        name="No name",
+        proper_motion_dec=0.0,
+        proper_motion_ra=0.0,
+        ra="00:00:00.000",
+    )
+
+    eso_target.use_sidereal_target(sidereal_target)
+
+    assert eso_target.name == "Test Target"
+    assert eso_target.ra == "24:30:00.000"
+    assert eso_target.dec == "12:30:00.000"

--- a/tests/module/test_types.py
+++ b/tests/module/test_types.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 
+from astropy.coordinates import Angle
 from astropy.time import Time
 from pydantic import BaseModel
 
@@ -13,8 +14,8 @@ class Window(BaseModel):
     used for testing the custom time type
     """
 
-    start: aeonlib.types.Time | datetime | None = None
-    end: aeonlib.types.Time | datetime
+    start: aeonlib.types.Time | None = None
+    end: aeonlib.types.Time
 
 
 class TestAstropyTime:
@@ -80,3 +81,48 @@ class TestAstropyTime:
         assert window.start == Time(datetime(2025, 4, 10, 0, 0, 0, 0))
         assert isinstance(window.end, Time)
         assert window.end == Time(datetime(2025, 4, 11, 0, 0, 0, 0))
+
+
+class Target(BaseModel):
+    """
+    Test model for testing custom angle type
+    """
+
+    ra: aeonlib.types.Angle
+    dec: aeonlib.types.Angle
+
+
+class TestAstropyAngle:
+    def test_from_angle(self):
+        """Test angles constructed from astropy Angle objects dump to json as strings"""
+        t = Target(ra=Angle(10, unit="deg"), dec=Angle(20, unit="deg"))
+        dumped = t.model_dump_json()
+        assert dumped == '{"ra":"10d00m00s","dec":"20d00m00s"}'
+
+    def test_from_str(self):
+        """Test angles constructed from strings dump to json as formatted strings"""
+        t = Target(ra="1h2m3s", dec="2d")
+        dumped = t.model_dump_json()
+        assert dumped == '{"ra":"1h02m03s","dec":"2d00m00s"}'
+
+    def test_angle_attributes(self):
+        """Test angles are accessible on the model"""
+        t = Target(ra="1h", dec="2d")
+        assert isinstance(t.ra, Angle)
+        assert t.ra.hour == 1
+        assert isinstance(t.dec, Angle)
+        assert t.dec.degree == 2
+
+    def test_from_json(self):
+        """Test models can be constructed from json"""
+        target_json = json.dumps(
+            {
+                "ra": "1h",
+                "dec": "2d",
+            }
+        )
+        target = Target.model_validate_json(target_json)
+        assert isinstance(target.ra, Angle)
+        assert target.ra.hour == 1
+        assert isinstance(target.dec, Angle)
+        assert target.dec.degree == 2

--- a/tests/module/test_types.py
+++ b/tests/module/test_types.py
@@ -97,13 +97,19 @@ class TestAstropyAngle:
         """Test angles constructed from astropy Angle objects dump to json as strings"""
         t = Target(ra=Angle(10, unit="deg"), dec=Angle(20, unit="deg"))
         dumped = t.model_dump_json()
-        assert dumped == '{"ra":"10d00m00s","dec":"20d00m00s"}'
+        assert dumped == '{"ra":"10","dec":"20"}'
 
     def test_from_str(self):
         """Test angles constructed from strings dump to json as formatted strings"""
         t = Target(ra="1h2m3s", dec="2d")
         dumped = t.model_dump_json()
-        assert dumped == '{"ra":"1h02m03s","dec":"2d00m00s"}'
+        assert dumped == '{"ra":"1.03417","dec":"2"}'
+
+    def test_from_float(self):
+        """Test angles constructed from floats dump to json as formatted strings"""
+        t = Target(ra=10, dec=20)
+        dumped = t.model_dump_json()
+        assert dumped == '{"ra":"10","dec":"20"}'
 
     def test_angle_attributes(self):
         """Test angles are accessible on the model"""
@@ -126,3 +132,17 @@ class TestAstropyAngle:
         assert target.ra.hour == 1
         assert isinstance(target.dec, Angle)
         assert target.dec.degree == 2
+
+    def test_from_json_float(self):
+        """Test models can be constructed from json with float values"""
+        target_json = json.dumps(
+            {
+                "ra": 10.0,
+                "dec": 20.0,
+            }
+        )
+        target = Target.model_validate_json(target_json)
+        assert isinstance(target.ra, Angle)
+        assert target.ra.degree == 10
+        assert isinstance(target.dec, Angle)
+        assert target.dec.degree == 20

--- a/tests/ocs/lco_requests.py
+++ b/tests/ocs/lco_requests.py
@@ -1,12 +1,11 @@
 from datetime import datetime, timedelta
 
-from aeonlib.models import Window
+from aeonlib.models import SiderealTarget, Window
 from aeonlib.ocs import (
     Constraints,
     Location,
     Request,
     RequestGroup,
-    SiderealTarget,
 )
 from aeonlib.ocs.lco.instruments import (
     Lco1M0ScicamSinistro,

--- a/tests/ocs/test_models.py
+++ b/tests/ocs/test_models.py
@@ -3,13 +3,12 @@ from datetime import datetime, timedelta
 import pytest
 from pydantic import ValidationError
 
-from aeonlib.models import Window
+from aeonlib.models import SiderealTarget, Window
 from aeonlib.ocs import (
     Constraints,
     Location,
     Request,
     RequestGroup,
-    SiderealTarget,
 )
 from aeonlib.ocs.lco.instruments import Lco1M0ScicamSinistro
 


### PR DESCRIPTION
Extracts the two target types, SiderealTarget and NonSiderealTarget to a module level model, and adds functions to the ESO facility to use these models to populate Observation Blocks.

Additionally, adds an Angle type for all target fields that are actually angles.