### PR TITLE
Docs/major planet docstring update

### DIFF
--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -91,9 +91,9 @@ class NonSiderealTarget(BaseModel):
     diff_azimuth_acceleration: float | None = None
     """Differential azimuth acceleration (arcsec/s^2)"""  # Satellite Only
     meanlong: Angle | None = None
-    """Mean longitude (angle in degrees)"""  # No idea what this is.
+    """Mean longitude (angle in degrees)"""  # Major Planet Only
     longofperih: Angle | None = None
-    """Longitude of perihelion (angle in degrees)"""  # No idea what this is.
+    """Longitude of perihelion (angle in degrees)"""  # Major Planet Only
     extra_params: dict[Any, Any] = {}
 
 

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -72,7 +72,7 @@ class NonSiderealTarget(BaseModel):
     """Mean anomaly (angle in degrees)"""
     perihdist: Annotated[float, NonNegativeFloat] | None = None
     """Perihelion distance (AU)"""  # Comet Only
-    epochofperih: Annotated[float, Le(240_000), Le(100_000)] | None = None
+    epochofperih: Annotated[float, Ge(10_000), Le(100_000)] | None = None
     """Epoch of perihelion (MJD)"""  # Comet Only
     dailymot: float | None = None
     """Daily motion (angle in degrees)"""  # Major Planet Only


### PR DESCRIPTION
I do have an idea what these two parameters are... ;-)
These two parameters are only needed and provided for major planets (and are needed for feeding to e.g. `sla_planel`) but are related to the other 2 existing parameters; details of the relation are shown in
step 2. of 'Formulae for using the Keplerian elements' on https://ssd.jpl.nasa.gov/planets/approx_pos.html
Also `epochofperih` (Epoch of perihelion) is also a MJD so should have the same valid range as the other MJD quantity `epochofel` the epoch of elements (reference time for elements' validity)