### PR TITLE
Target type per element scheme + satellite

### DIFF
--- a/codegen/lco/templates/instruments.jinja
+++ b/codegen/lco/templates/instruments.jinja
@@ -4,7 +4,7 @@ from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
 from pydantic.types import NonNegativeInt, PositiveInt
 
-from aeonlib.models import SiderealTarget, NonSiderealTarget
+from aeonlib.models import TARGET_TYPES
 from aeonlib.ocs.target_models import Constraints
 from aeonlib.ocs.config_models import Roi
 
@@ -64,7 +64,7 @@ class {{ ctx.class_name }}(BaseModel):
     instrument_configs: list[{{ ctx.class_name }}Config] = []
     acquisition_config: {{ ctx.class_name }}AcquisitionConfig
     guiding_config: {{ ctx.class_name }}GuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = {{ ctx.class_name }}Config

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -57,9 +57,9 @@ class _NonSiderealTarget(BaseModel):
     epochofel: TimeMJD
     """The epoch of the orbital elements (MJD)"""
     orbinc: Angle
-    """Orbital inclination (angle in degrees)"""
+    """Orbital inclination"""
     longascnode: Angle
-    """Longitude of ascending node (angle in degrees)"""
+    """Longitude of ascending node"""
     eccentricity: NonNegativeFloat
     """Eccentricity of the orbit"""
     extra_params: dict[Any, Any] = {}
@@ -68,29 +68,29 @@ class _NonSiderealTarget(BaseModel):
 class AsaMajorPlanetTarget(_NonSiderealTarget):
     scheme: Literal["ASA_MAJOR_PLANET"] = "ASA_MAJOR_PLANET"
     longofperih: Angle
-    """Longitude of perihelion (angle in degrees)"""
+    """Longitude of perihelion"""
     meandist: Annotated[float, NonNegativeFloat]
     """Semi-major axis (AU)"""
     meanlong: Angle
-    """Mean longitude (angle in degrees)"""
+    """Mean longitude"""
     dailymot: float
-    """Daily motion (angle in degrees)"""
+    """Daily motion """
 
 
 class AsaMinorPlanetTarget(_NonSiderealTarget):
     scheme: Literal["ASA_MINOR_PLANET"] = "ASA_MINOR_PLANET"
     argofperih: Angle
-    """Argument of perihelion (angle in degrees)"""
+    """Argument of perihelion"""
     meandist: Annotated[float, NonNegativeFloat]
     """Semi-major axis (AU)"""
     meananom: Angle
-    """Mean anomaly (angle in degrees)"""
+    """Mean anomaly"""
 
 
 class AsaCometTarget(_NonSiderealTarget):
     scheme: Literal["ASA_COMET"] = "ASA_COMET"
     argofperih: Angle
-    """Argument of perihelion (angle in degrees)"""
+    """Argument of perihelion"""
     perihdist: Annotated[float, NonNegativeFloat]
     """Perihelion distance (AU)"""
     epochofperih: TimeMJD
@@ -100,19 +100,19 @@ class AsaCometTarget(_NonSiderealTarget):
 class JplMajorPlanetTarget(_NonSiderealTarget):
     scheme: Literal["JPL_MAJOR_PLANET"] = "JPL_MAJOR_PLANET"
     argofperih: Angle
-    """Argument of perihelion (angle in degrees)"""
+    """Argument of perihelion"""
     meandist: Annotated[float, NonNegativeFloat]
     """Semi-major axis (AU)"""
     meananom: Angle
-    """Mean anomaly (angle in degrees)"""
+    """Mean anomaly"""
     dailymot: float
-    """Daily motion (angle in degrees)"""
+    """Daily motion"""
 
 
 class JplMinorPlanetTarget(_NonSiderealTarget):
     scheme: Literal["JPL_MINOR_PLANET"] = "JPL_MINOR_PLANET"
     argofperih: Angle
-    """Argument of perihelion (angle in degrees)"""
+    """Argument of perihelion"""
     perihdist: Annotated[float, NonNegativeFloat]
     """Perihelion distance (AU)"""
     epochofperih: TimeMJD
@@ -122,17 +122,17 @@ class JplMinorPlanetTarget(_NonSiderealTarget):
 class MpcMinorPlanetTarget(_NonSiderealTarget):
     scheme: Literal["MPC_MINOR_PLANET"] = "MPC_MINOR_PLANET"
     argofperih: Angle
-    """Argument of perihelion (angle in degrees)"""
+    """Argument of perihelion"""
     meandist: Annotated[float, NonNegativeFloat]
     """Semi-major axis (AU)"""
     meananom: Angle
-    """Mean anomaly (angle in degrees)"""
+    """Mean anomaly"""
 
 
 class MpcCometTarget(_NonSiderealTarget):
     scheme: Literal["MPC_COMET"] = "MPC_COMET"
     argofperih: Angle
-    """Argument of perihelion (angle in degrees)"""
+    """Argument of perihelion"""
     perihdist: Annotated[float, NonNegativeFloat]
     """Perihelion distance (AU)"""
     epochofperih: TimeMJD

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -139,7 +139,7 @@ class MpcCometTarget(_NonSiderealTarget):
     """Epoch of perihelion (MJD)"""
 
 
-class SatelliteTarget(BaseModel):
+class GeocentricSatelliteTarget(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
     name: Annotated[str, StringConstraints(max_length=50)]
     type: Literal["SATELLITE"] = "SATELLITE"
@@ -169,5 +169,5 @@ TARGET_TYPES = Union[
     JplMinorPlanetTarget,
     MpcMinorPlanetTarget,
     MpcCometTarget,
-    SatelliteTarget,
+    GeocentricSatelliteTarget,
 ]

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -2,7 +2,7 @@
 Models shared between facilities.
 """
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Union
 
 from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
@@ -40,66 +40,134 @@ class SiderealTarget(BaseModel):
     """Parallax of the Target in mas, max 2000. Defaults to 0."""
 
 
-class NonSiderealTarget(BaseModel):
-    model_config = ConfigDict(validate_assignment=True)
-    name: Annotated[str, StringConstraints(max_length=50)] = "string"
-    """The name of this Target"""
-    type: Literal["ORBITAL_ELEMENTS", "SATELLITE"]
-    """The type of this Target TODO: Where does HOUR_ANGLE make sense?"""
-    scheme: Literal[
-        "ASA_MAJOR_PLANET",
-        "ASA_MINOR_PLANET",
-        "ASA_COMET",
-        "JPL_MAJOR_PLANET",
-        "JPL_MINOR_PLANET",
-        "MPC_MINOR_PLANET",
-        "MPC_COMET",
-    ]
-    """The Target scheme to use"""
-    epochofel: Time
-    """The epoch of the orbital elements (MJD)"""
-    orbinc: Angle
-    """Orbital inclination (angle in degrees)"""
-    longascnode: Angle
-    """Longitude of ascending node (angle in degrees)"""
-    argofperih: Angle
-    """Argument of perihelion (angle in degrees)"""
-    eccentricity: NonNegativeFloat
-    """Eccentricity of the orbit"""
-    meandist: Annotated[float, NonNegativeFloat] | None = None
-    """Semi-major axis (AU)"""  # Not Comet
-    meananom: Angle | None = None
-    """Mean anomaly (angle in degrees)"""
-    perihdist: Annotated[float, NonNegativeFloat] | None = None
-    """Perihelion distance (AU)"""  # Comet Only
-    epochofperih: Time | None = None
-    """Epoch of perihelion (MJD)"""  # Comet Only
-    dailymot: float | None = None
-    """Daily motion (angle in degrees)"""  # Major Planet Only
-    altitude: Angle | None = None
-    """Altitude of this Target in decimal degrees"""  # Satellite Only
-    azimuth: Angle | None = None
-    """Azimuth of this Target in decimal degrees east of North"""  # Satellite Only
-    diff_altitude_rate: float | None = None
-    """Differential altitude rate (arcsec/s)"""  # Satellite Only
-    diff_azimuth_rate: float | None = None
-    """Differential azimuth rate (arcsec/s)"""  # Satellite Only
-    diff_epoch: float | None = None
-    """Reference time for non-sidereal motion (MJD)"""  # Satellite Only
-    diff_altitude_acceleration: float | None = None
-    """Differential altitude acceleration (arcsec/s^2)"""  # Satellite Only
-    diff_azimuth_acceleration: float | None = None
-    """Differential azimuth acceleration (arcsec/s^2)"""  # Satellite Only
-    meanlong: Angle | None = None
-    """Mean longitude (angle in degrees)"""  # Major Planet Only
-    longofperih: Angle | None = None
-    """Longitude of perihelion (angle in degrees)"""  # Major Planet Only
-    extra_params: dict[Any, Any] = {}
-
-
 class Window(BaseModel):
     """A general time window"""
 
     model_config = ConfigDict(validate_assignment=True)
     start: Time | None = None
     end: Time
+
+
+class _NonSiderealTarget(BaseModel):
+    """Base class for non-sidereal targets, should not be used directly"""
+
+    model_config = ConfigDict(validate_assignment=True)
+    type: Literal["ORBITAL_ELEMENTS"] = "ORBITAL_ELEMENTS"
+    name: Annotated[str, StringConstraints(max_length=50)]
+    epochofel: Time
+    """The epoch of the orbital elements (MJD)"""
+    orbinc: Angle
+    """Orbital inclination (angle in degrees)"""
+    longascnode: Angle
+    """Longitude of ascending node (angle in degrees)"""
+    eccentricity: NonNegativeFloat
+    """Eccentricity of the orbit"""
+    extra_params: dict[Any, Any] = {}
+
+
+class AsaMajorPlanetTarget(_NonSiderealTarget):
+    scheme: Literal["ASA_MAJOR_PLANET"] = "ASA_MAJOR_PLANET"
+    longofperih: Angle
+    """Longitude of perihelion (angle in degrees)"""
+    meandist: Annotated[float, NonNegativeFloat]
+    """Semi-major axis (AU)"""
+    meanlong: Angle
+    """Mean longitude (angle in degrees)"""
+    dailymot: float
+    """Daily motion (angle in degrees)"""
+
+
+class AsaMinorPlanetTarget(_NonSiderealTarget):
+    scheme: Literal["ASA_MINOR_PLANET"] = "ASA_MINOR_PLANET"
+    argofperih: Angle
+    """Argument of perihelion (angle in degrees)"""
+    meandist: Annotated[float, NonNegativeFloat]
+    """Semi-major axis (AU)"""
+    meananom: Angle
+    """Mean anomaly (angle in degrees)"""
+
+
+class AsaCometTarget(_NonSiderealTarget):
+    scheme: Literal["ASA_COMET"] = "ASA_COMET"
+    argofperih: Angle
+    """Argument of perihelion (angle in degrees)"""
+    perihdist: Annotated[float, NonNegativeFloat]
+    """Perihelion distance (AU)"""
+    epochofperih: Time
+    """Epoch of perihelion (MJD)"""
+
+
+class JplMajorPlanetTarget(_NonSiderealTarget):
+    scheme: Literal["JPL_MAJOR_PLANET"] = "JPL_MAJOR_PLANET"
+    argofperih: Angle
+    """Argument of perihelion (angle in degrees)"""
+    meandist: Annotated[float, NonNegativeFloat]
+    """Semi-major axis (AU)"""
+    meananom: Angle
+    """Mean anomaly (angle in degrees)"""
+    dailymot: float
+    """Daily motion (angle in degrees)"""
+
+
+class JplMinorPlanetTarget(_NonSiderealTarget):
+    scheme: Literal["JPL_MINOR_PLANET"] = "JPL_MINOR_PLANET"
+    argofperih: Angle
+    """Argument of perihelion (angle in degrees)"""
+    perihdist: Annotated[float, NonNegativeFloat]
+    """Perihelion distance (AU)"""
+    epochofperih: Time
+    """Epoch of perihelion (MJD)"""
+
+
+class MpcMinorPlanetTarget(_NonSiderealTarget):
+    scheme: Literal["MPC_MINOR_PLANET"] = "MPC_MINOR_PLANET"
+    argofperih: Angle
+    """Argument of perihelion (angle in degrees)"""
+    meandist: Annotated[float, NonNegativeFloat]
+    """Semi-major axis (AU)"""
+    meananom: Angle
+    """Mean anomaly (angle in degrees)"""
+
+
+class MpcCometTarget(_NonSiderealTarget):
+    scheme: Literal["MPC_COMET"] = "MPC_COMET"
+    argofperih: Angle
+    """Argument of perihelion (angle in degrees)"""
+    perihdist: Annotated[float, NonNegativeFloat]
+    """Perihelion distance (AU)"""
+    epochofperih: Time
+    """Epoch of perihelion (MJD)"""
+
+
+class SatelliteTarget(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+    name: Annotated[str, StringConstraints(max_length=50)]
+    type: Literal["SATELLITE"] = "SATELLITE"
+    altitude: Angle
+    """Altitude of this Target in decimal degrees"""
+    azimuth: Angle
+    """Azimuth of this Target in decimal degrees east of North"""
+    diff_altitude_rate: float
+    """Differential altitude rate (arcsec/s)"""
+    diff_azimuth_rate: float
+    """Differential azimuth rate (arcsec/s)"""
+    diff_epoch: float
+    """Reference time for non-sidereal motion (MJD)"""
+    diff_altitude_acceleration: float
+    """Differential altitude acceleration (arcsec/s^2)"""
+    diff_azimuth_acceleration: float
+    """Differential azimuth acceleration (arcsec/s^2)"""
+    extra_params: dict[Any, Any] = {}
+
+
+TARGET_TYPES = Union[
+    SiderealTarget,
+    AsaMajorPlanetTarget,
+    AsaMinorPlanetTarget,
+    AsaCometTarget,
+    JplMajorPlanetTarget,
+    JplMinorPlanetTarget,
+    MpcMinorPlanetTarget,
+    MpcCometTarget,
+    SatelliteTarget,
+]

--- a/src/aeonlib/models.py
+++ b/src/aeonlib/models.py
@@ -73,8 +73,8 @@ class AsaMajorPlanetTarget(_NonSiderealTarget):
     """Semi-major axis (AU)"""
     meanlong: Angle
     """Mean longitude"""
-    dailymot: float
-    """Daily motion """
+    dailymot: Angle
+    """Mean Daily motion"""
 
 
 class AsaMinorPlanetTarget(_NonSiderealTarget):
@@ -105,8 +105,8 @@ class JplMajorPlanetTarget(_NonSiderealTarget):
     """Semi-major axis (AU)"""
     meananom: Angle
     """Mean anomaly"""
-    dailymot: float
-    """Daily motion"""
+    dailymot: Angle
+    """Mean Daily motion"""
 
 
 class JplMinorPlanetTarget(_NonSiderealTarget):

--- a/src/aeonlib/ocs/lco/instruments.py
+++ b/src/aeonlib/ocs/lco/instruments.py
@@ -4,7 +4,7 @@ from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
 from pydantic.types import NonNegativeInt, PositiveInt
 
-from aeonlib.models import SiderealTarget, NonSiderealTarget
+from aeonlib.models import TARGET_TYPES
 from aeonlib.ocs.target_models import Constraints
 from aeonlib.ocs.config_models import Roi
 
@@ -53,7 +53,7 @@ class Lco0M4ScicamQhy600(BaseModel):
     instrument_configs: list[Lco0M4ScicamQhy600Config] = []
     acquisition_config: Lco0M4ScicamQhy600AcquisitionConfig
     guiding_config: Lco0M4ScicamQhy600GuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = Lco0M4ScicamQhy600Config
@@ -105,7 +105,7 @@ class Lco1M0NresScicam(BaseModel):
     instrument_configs: list[Lco1M0NresScicamConfig] = []
     acquisition_config: Lco1M0NresScicamAcquisitionConfig
     guiding_config: Lco1M0NresScicamGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = Lco1M0NresScicamConfig
@@ -158,7 +158,7 @@ class Lco1M0ScicamSinistro(BaseModel):
     instrument_configs: list[Lco1M0ScicamSinistroConfig] = []
     acquisition_config: Lco1M0ScicamSinistroAcquisitionConfig
     guiding_config: Lco1M0ScicamSinistroGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = Lco1M0ScicamSinistroConfig
@@ -212,7 +212,7 @@ class Lco2M0FloydsScicam(BaseModel):
     instrument_configs: list[Lco2M0FloydsScicamConfig] = []
     acquisition_config: Lco2M0FloydsScicamAcquisitionConfig
     guiding_config: Lco2M0FloydsScicamGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = Lco2M0FloydsScicamConfig
@@ -268,7 +268,7 @@ class Lco2M0ScicamMuscat(BaseModel):
     instrument_configs: list[Lco2M0ScicamMuscatConfig] = []
     acquisition_config: Lco2M0ScicamMuscatAcquisitionConfig
     guiding_config: Lco2M0ScicamMuscatGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = Lco2M0ScicamMuscatConfig
@@ -321,7 +321,7 @@ class LcoBlancoNewfirm(BaseModel):
     instrument_configs: list[LcoBlancoNewfirmConfig] = []
     acquisition_config: LcoBlancoNewfirmAcquisitionConfig
     guiding_config: LcoBlancoNewfirmGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = LcoBlancoNewfirmConfig

--- a/src/aeonlib/ocs/soar/instruments.py
+++ b/src/aeonlib/ocs/soar/instruments.py
@@ -4,7 +4,7 @@ from annotated_types import Le
 from pydantic import BaseModel, ConfigDict
 from pydantic.types import NonNegativeInt, PositiveInt
 
-from aeonlib.models import SiderealTarget, NonSiderealTarget
+from aeonlib.models import TARGET_TYPES
 from aeonlib.ocs.target_models import Constraints
 from aeonlib.ocs.config_models import Roi
 
@@ -53,7 +53,7 @@ class SoarGhtsBluecam(BaseModel):
     instrument_configs: list[SoarGhtsBluecamConfig] = []
     acquisition_config: SoarGhtsBluecamAcquisitionConfig
     guiding_config: SoarGhtsBluecamGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = SoarGhtsBluecamConfig
@@ -107,7 +107,7 @@ class SoarGhtsBluecamImager(BaseModel):
     instrument_configs: list[SoarGhtsBluecamImagerConfig] = []
     acquisition_config: SoarGhtsBluecamImagerAcquisitionConfig
     guiding_config: SoarGhtsBluecamImagerGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = SoarGhtsBluecamImagerConfig
@@ -160,7 +160,7 @@ class SoarGhtsRedcam(BaseModel):
     instrument_configs: list[SoarGhtsRedcamConfig] = []
     acquisition_config: SoarGhtsRedcamAcquisitionConfig
     guiding_config: SoarGhtsRedcamGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = SoarGhtsRedcamConfig
@@ -214,7 +214,7 @@ class SoarGhtsRedcamImager(BaseModel):
     instrument_configs: list[SoarGhtsRedcamImagerConfig] = []
     acquisition_config: SoarGhtsRedcamImagerAcquisitionConfig
     guiding_config: SoarGhtsRedcamImagerGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = SoarGhtsRedcamImagerConfig
@@ -267,7 +267,7 @@ class SoarTriplespec(BaseModel):
     instrument_configs: list[SoarTriplespecConfig] = []
     acquisition_config: SoarTriplespecAcquisitionConfig
     guiding_config: SoarTriplespecGuidingConfig
-    target: SiderealTarget | NonSiderealTarget
+    target: TARGET_TYPES
     constraints: Constraints
 
     config_class = SoarTriplespecConfig

--- a/tests/ocs/test_models.py
+++ b/tests/ocs/test_models.py
@@ -5,7 +5,7 @@ from astropy.time import Time
 from pydantic import ValidationError
 
 from aeonlib.conf import Settings
-from aeonlib.models import NonSiderealTarget, SiderealTarget, Window
+from aeonlib.models import JplMinorPlanetTarget, SiderealTarget, Window
 from aeonlib.ocs import (
     Constraints,
     Location,
@@ -130,17 +130,14 @@ class TestSerialization:
         This is likely specific to LCO/OCS so only the LCO Facility has this behavior.
         """
         facility = LcoFacility(settings=Settings(lco_token="", lco_api_root=""))
-        target = NonSiderealTarget(
+        target = JplMinorPlanetTarget(
             name="mover",
-            type="ORBITAL_ELEMENTS",
-            scheme="JPL_MINOR_PLANET",
             epochofel=datetime(2025, 1, 1),  # Time as datetime
+            perihdist=1.0,
             orbinc=0.0,
             longascnode=0.0,
             argofperih=0.0,
             eccentricity=1.0,
-            meandist=1.0,
-            meananom=0.0,
             epochofperih=Time(2460676.5, format="jd", scale="tt"),  # Time as JD
         )
         request_group.requests[0].configurations[0].target = target


### PR DESCRIPTION
Removes NonSiderealTarget, and creates on Type per scheme. This should simplify constructing non-sidereal targets.

No more `| None = None` ! 