### PR TITLE
Use optional dependencies instead of dependency groups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project
-        run: uv sync --dev --group eso --group lt
+        run: uv sync --dev --extra eso --extra lt
 
       - name: Run tests
         run: uv run pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Before implementing a new facility it may be worth studying the current facility
 * [EsoFacility](./src/aeonlib/eso/facility.py)
 
 ### Declaring dependencies
-AEONlib uses [dependency groups](https://peps.python.org/pep-0735/) to separate the dependencies of each facility module. This is because it is unlikely that one will utilize all facilities offered by AEONlib. Because some facilities have completely unique transitive dependencies, this ends up saving a lot of unnecessary package installations.
+AEONlib uses [optional dependencies](https://peps.python.org/pep-0631/) to separate the dependencies of each facility module. This is because it is unlikely that one will utilize all facilities offered by AEONlib. Because some facilities have completely unique transitive dependencies, this ends up saving a lot of unnecessary package installations.
 
 A facility might not need any additional dependencies - the base group includes [httpx](https://www.python-httpx.org/) for http requests and [Pydantic](https://pydantic.dev/) for data de/serialization.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ A facility might not need any additional dependencies - the base group includes 
 If the facility does need additional dependencies, add a group to `pyproject.toml` and list them there. Afterward make a note in the facility's README section with the name of the group library consumers will need to install.
 
 ### Configuration values
-Most facilities will require some kind of runtime configuration, such as authentication keys. AEONlib leverages [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) for settings management. Any facility that requires runtime configuration must place the keys in `src/aenlib/conf.py`. Reading from files or environmental variables directly inside a facility will not be accepted.
+Most facilities will require some kind of runtime configuration, such as authentication keys. AEONlib leverages [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/) for settings management. Any facility that requires runtime configuration must place the keys in `src/aeonlib/conf.py`. Reading from files or environmental variables directly inside a facility will not be accepted.
 
 Using `conf.py` ensures that consumers have a consistent and facility agnostic means of providing configuration to AEONlib powered applications, whether it be via .env files, environmental variables, or direct instantiation.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Full documentation: TODO
 To use the ESO facility, you must install the `eso` group:
 ```bash
 pip install aeonlib[eso]
-uv sync --group eso
+uv sync --extra eso
 poetry install --with eso
 ```
 
@@ -176,7 +176,7 @@ eso_password: str = ""
 To use the LT facility, you must install the `lt` group:
 ```bash
 pip install aeonlib[lt]
-uv sync --group lt
+uv sync --extra lt
 poetry install --with lt
 ```
 ### Configuration Values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ codegen = [
 ]
 
 dev = ["pytest>=8.3.5"]
+
+[project.optional-dependencies]
 eso = ["p2api>=1.0.10"]
 lt = [
     "lxml>=5.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -13,14 +13,7 @@ dependencies = [
     { name = "pydantic-settings" },
 ]
 
-[package.dev-dependencies]
-codegen = [
-    { name = "jinja2" },
-    { name = "textcase" },
-]
-dev = [
-    { name = "pytest" },
-]
+[package.optional-dependencies]
 eso = [
     { name = "p2api" },
 ]
@@ -30,13 +23,27 @@ lt = [
     { name = "suds" },
 ]
 
+[package.dev-dependencies]
+codegen = [
+    { name = "jinja2" },
+    { name = "textcase" },
+]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "astropy", specifier = ">=7.0.1" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "lxml", marker = "extra == 'lt'", specifier = ">=5.4.0" },
+    { name = "lxml-stubs", marker = "extra == 'lt'", specifier = ">=0.5.1" },
+    { name = "p2api", marker = "extra == 'eso'", specifier = ">=1.0.10" },
     { name = "pydantic", specifier = ">=2.11.1" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
+    { name = "suds", marker = "extra == 'lt'", specifier = ">=1.2.0" },
 ]
+provides-extras = ["eso", "lt"]
 
 [package.metadata.requires-dev]
 codegen = [
@@ -44,12 +51,6 @@ codegen = [
     { name = "textcase", specifier = ">=0.2.1" },
 ]
 dev = [{ name = "pytest", specifier = ">=8.3.5" }]
-eso = [{ name = "p2api", specifier = ">=1.0.10" }]
-lt = [
-    { name = "lxml", specifier = ">=5.4.0" },
-    { name = "lxml-stubs", specifier = ">=0.5.1" },
-    { name = "suds", specifier = ">=1.2.0" },
-]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
The PR addresses two issues:

1. It replaces the dependency groups `eso` and `lt` with optional dependencies.
2. It fixes a typo in a file path in the contributing guidelines.
