### PR TITLE
Annotation for defining Pydantic types based on AstroPy's Quantity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ assert type(observation.wavelength_range[0]) == Quantity
 assert type(observation.wavelength_range[1]) == Quantity
 ```
 
+As you cannot use the validators of the `annotated_types` library with `Quantity` objects, the `aeonlib.validators` module provides some alternative validators, which you can use instead.
+
 These types eliminate the need for the facility user to need to remember which exact format a facility requires (time in hms? Or ISO UTC?) and simply pass in higher level objects instead.
 
 Aeonlib also defines a few high level models: `aeonlib.models.Window` and several target types. If a facility can translate these models or even use them directly it should. This means a consumer of Aeonlib can define these high level models once, for example from a data alert stream, and use them with every facility for which they want to perform observations.

--- a/src/aeonlib/validators.py
+++ b/src/aeonlib/validators.py
@@ -1,0 +1,164 @@
+"""
+This module defines some Pydantic validators.
+
+The validators are
+"""
+
+from typing import Any
+
+import astropy.coordinates
+from astropy import units as u
+from pydantic import AfterValidator
+
+
+def _check_gt(a: Any, b: Any) -> Any:
+    if a <= b:
+        raise ValueError(f"{a} is not greater than to {b}.")
+    return a
+
+
+def _check_ge(a: Any, b: Any) -> Any:
+    if a < b:
+        raise ValueError(f"{a} is not greater than or equal to {b}.")
+    return a
+
+
+def _check_lt(a: Any, b: Any) -> None:
+    if a >= b:
+        raise ValueError(f"{a} is not less than to {b}.")
+    return a
+
+
+def _check_le(a: Any, b: Any) -> None:
+    if a > b:
+        raise ValueError(f"{a} is not less than or equal to {b}.")
+    return a
+
+
+def Gt(value: Any):
+    """
+    Return a Pydantic validator for checking a greater than relation.
+
+    The returned validator can be used in a type annotation::
+
+        import pydantic
+
+        class DummyModel(pydantic.BaseModel):
+            duration: Annotated[float, Gt(4)]
+
+    Pydantic will first perform its own internal validation and then check whether
+    the field value is greater than the argument passed to `Gt` (4 in the example
+    above).
+
+    It is up to the user to ensure that the field value and the argument of `Gt` can
+    be compared.
+
+    Parameters
+    ----------
+    value
+       Value against which to compare.
+
+    Returns
+    -------
+    A validator for checking a greater than relation.
+    """
+    return AfterValidator(lambda v: _check_gt(v, value))
+
+
+def Ge(value: Any):
+    """
+    Return a Pydantic validator for checking a greater than or equal to relation.
+
+    The returned validator can be used in a type annotation::
+
+        import pydantic
+
+        class DummyModel(pydantic.BaseModel):
+            duration: Annotated[float, Ge(4)]
+
+    Pydantic will first perform its own internal validation and then check whether
+    the field value is greater than or equal to the argument passed to `Ge` (4 in the
+    example above).
+
+    It is up to the user to ensure that the field value and the argument of `Ge` can
+    be compared.
+
+    Parameters
+    ----------
+    value
+       Value against which to compare.
+
+    Returns
+    -------
+    A validator for checking a greater than or equal to relation.
+    """
+    return AfterValidator(lambda v: _check_ge(v, value))
+
+
+def Lt(value: Any):
+    """
+    Return a Pydantic validator for checking a less than relation.
+
+    The returned validator can be used in a type annotation::
+
+        import pydantic
+
+        class DummyModel(pydantic.BaseModel):
+            height: Annotated[float, Lt(4)]
+
+    Pydantic will first perform its own internal validation and then check whether
+    the field value is less than or equal to the argument passed to `Lt` (4 in the
+    example above).
+
+    It is up to the user to ensure that the field value and the argument of `Lt` can
+    be compared.
+
+    Parameters
+    ----------
+    value
+       Value against which to compare.
+
+    Returns
+    -------
+    A validator for checking a less than relation.
+    """
+    return AfterValidator(lambda v: _check_lt(v, value))
+
+
+def Le(value: Any):
+    """
+    Return a Pydantic validator for checking a less than or equal to relation.
+
+    The returned validator can be used in a type annotation::
+
+        import pydantic
+
+        class DummyModel(pydantic.BaseModel):
+            height: Annotated[float, Le(4)]
+
+    Pydantic will first perform its own internal validation and then check whether
+    the field value is less than or equal to the argument passed to `Le` (4 in the
+    example above).
+
+    It is up to the user to ensure that the field value and the argument of `Le` can
+    be compared.
+
+    Parameters
+    ----------
+    value
+       Value against which to compare.
+
+    Returns
+    -------
+    A validator for checking a less than or equal to relation.
+    """
+    return AfterValidator(lambda v: _check_le(v, value))
+
+
+def check_in_visibility_range(
+    dec: astropy.coordinates.Angle,
+) -> astropy.coordinates.Angle:
+    if dec < -76 * u.deg or dec > 11 * u.deg:
+        raise ValueError("Not in SALT's visibility range (between -76 and 11 degrees).")
+
+    return dec

--- a/src/aeonlib/validators.py
+++ b/src/aeonlib/validators.py
@@ -1,8 +1,4 @@
-"""
-This module defines some Pydantic validators.
-
-The validators are
-"""
+"""This module defines some Pydantic validators."""
 
 from typing import Any
 
@@ -12,30 +8,30 @@ from pydantic import AfterValidator
 
 
 def _check_gt(a: Any, b: Any) -> Any:
-    if a <= b:
+    if a is not None and b is not None and a <= b:
         raise ValueError(f"{a} is not greater than to {b}.")
     return a
 
 
 def _check_ge(a: Any, b: Any) -> Any:
-    if a < b:
+    if a is not None and b is not None and a < b:
         raise ValueError(f"{a} is not greater than or equal to {b}.")
     return a
 
 
 def _check_lt(a: Any, b: Any) -> None:
-    if a >= b:
+    if a is not None and b is not None and a >= b:
         raise ValueError(f"{a} is not less than to {b}.")
     return a
 
 
 def _check_le(a: Any, b: Any) -> None:
-    if a > b:
+    if a is not None and b is not None and a > b:
         raise ValueError(f"{a} is not less than or equal to {b}.")
     return a
 
 
-def Gt(value: Any):
+def GreaterThan(value: Any):
     """
     Return a Pydantic validator for checking a greater than relation.
 
@@ -44,14 +40,14 @@ def Gt(value: Any):
         import pydantic
 
         class DummyModel(pydantic.BaseModel):
-            duration: Annotated[float, Gt(4)]
+            duration: Annotated[float, GreaterThan(4)]
 
     Pydantic will first perform its own internal validation and then check whether
-    the field value is greater than the argument passed to `Gt` (4 in the example
-    above).
+    the field value is greater than the argument passed to `GreaterThan` (4 in the
+    example above).
 
-    It is up to the user to ensure that the field value and the argument of `Gt` can
-    be compared.
+    It is up to the user to ensure that the field value and the argument of
+    `GreaterThan` can be compared.
 
     Parameters
     ----------
@@ -65,7 +61,7 @@ def Gt(value: Any):
     return AfterValidator(lambda v: _check_gt(v, value))
 
 
-def Ge(value: Any):
+def GreaterEqual(value: Any):
     """
     Return a Pydantic validator for checking a greater than or equal to relation.
 
@@ -74,14 +70,14 @@ def Ge(value: Any):
         import pydantic
 
         class DummyModel(pydantic.BaseModel):
-            duration: Annotated[float, Ge(4)]
+            duration: Annotated[float, GreaterEqual(4)]
 
     Pydantic will first perform its own internal validation and then check whether
-    the field value is greater than or equal to the argument passed to `Ge` (4 in the
-    example above).
+    the field value is greater than or equal to the argument passed to `GreaterEqual`
+    (4 in the example above).
 
-    It is up to the user to ensure that the field value and the argument of `Ge` can
-    be compared.
+    It is up to the user to ensure that the field value and the argument of
+    `GreaterEqual` can be compared.
 
     Parameters
     ----------
@@ -95,7 +91,7 @@ def Ge(value: Any):
     return AfterValidator(lambda v: _check_ge(v, value))
 
 
-def Lt(value: Any):
+def LessThan(value: Any):
     """
     Return a Pydantic validator for checking a less than relation.
 
@@ -104,14 +100,14 @@ def Lt(value: Any):
         import pydantic
 
         class DummyModel(pydantic.BaseModel):
-            height: Annotated[float, Lt(4)]
+            height: Annotated[float, LessThan(4)]
 
     Pydantic will first perform its own internal validation and then check whether
-    the field value is less than or equal to the argument passed to `Lt` (4 in the
-    example above).
+    the field value is less than or equal to the argument passed to `LessEqual` (4 in
+    the example above).
 
-    It is up to the user to ensure that the field value and the argument of `Lt` can
-    be compared.
+    It is up to the user to ensure that the field value and the argument of
+    `LessThan` can be compared.
 
     Parameters
     ----------
@@ -125,7 +121,7 @@ def Lt(value: Any):
     return AfterValidator(lambda v: _check_lt(v, value))
 
 
-def Le(value: Any):
+def LessEqual(value: Any):
     """
     Return a Pydantic validator for checking a less than or equal to relation.
 
@@ -134,14 +130,14 @@ def Le(value: Any):
         import pydantic
 
         class DummyModel(pydantic.BaseModel):
-            height: Annotated[float, Le(4)]
+            height: Annotated[float, LessEqual(4)]
 
     Pydantic will first perform its own internal validation and then check whether
-    the field value is less than or equal to the argument passed to `Le` (4 in the
-    example above).
+    the field value is less than or equal to the argument passed to `LessEqual` (4 in
+    the example above).
 
-    It is up to the user to ensure that the field value and the argument of `Le` can
-    be compared.
+    It is up to the user to ensure that the field value and the argument of
+    `LessEqual` can be compared.
 
     Parameters
     ----------

--- a/tests/module/test_validators.py
+++ b/tests/module/test_validators.py
@@ -1,0 +1,85 @@
+from contextlib import nullcontext
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from aeonlib.validators import Ge, Gt, Le, Lt
+
+
+class GtModel(BaseModel):
+    a: Annotated[int, Gt(4)]
+
+
+class GeModel(BaseModel):
+    a: Annotated[int, Ge(4)]
+
+
+class LtModel(BaseModel):
+    a: Annotated[int, Lt(4)]
+
+
+class LeModel(BaseModel):
+    a: Annotated[int, Le(4)]
+
+
+class TestValidators:
+    @pytest.mark.parametrize(
+        "a, expectation",
+        [
+            (3, pytest.raises(ValidationError)),
+            (4, pytest.raises(ValidationError)),
+            (5, nullcontext()),
+        ],
+    )
+    def test_greater_than(self, a, expectation):
+        """Test that the Gt validator validates correctly."""
+        with expectation:
+            GtModel(a=a)
+
+    def test_greater_than_does_not_change_field_value(self):
+        """Test that the field value is not changed by the Gt validator."""
+        assert GtModel(a=7).a == 7
+
+    @pytest.mark.parametrize(
+        "a, expectation",
+        [(3, pytest.raises(ValidationError)), (4, nullcontext()), (5, nullcontext())],
+    )
+    def test_greater_equal(self, a, expectation):
+        """Test that the Ge validator validates correctly."""
+        with expectation:
+            GeModel(a=a)
+
+    def test_greater_equal_does_not_change_field_value(self):
+        """Test that the field value is not changed by the Ge validator."""
+        assert GeModel(a=7).a == 7
+
+    @pytest.mark.parametrize(
+        "a, expectation",
+        [
+            (3, nullcontext()),
+            (4, pytest.raises(ValidationError)),
+            (5, pytest.raises(ValidationError)),
+        ],
+    )
+    def test_less_than(self, a, expectation):
+        """Test that the Lt validator validates correctly."""
+        with expectation:
+            LtModel(a=a)
+
+    def test_less_than_does_not_change_field_value(self):
+        """Test that the field value is not changed by the Lt validator."""
+        assert LtModel(a=2).a == 2
+
+    @pytest.mark.parametrize(
+        "a, expectation",
+        [(3, nullcontext()), (4, nullcontext()), (5, pytest.raises(ValidationError))],
+    )
+    def test_less_equal(self, a, expectation):
+        """Test that the Le validator validates correctly."""
+        with expectation:
+            LeModel(a=a)
+
+    def test_less_equal_does_not_change_field_value(self):
+        """Test that the field value is not changed by the Le validator."""
+        assert LeModel(a=2).a == 2

--- a/tests/module/test_validators.py
+++ b/tests/module/test_validators.py
@@ -4,23 +4,23 @@ from typing import Annotated
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from aeonlib.validators import Ge, Gt, Le, Lt
+from aeonlib.validators import GreaterEqual, GreaterThan, LessEqual, LessThan
 
 
-class GtModel(BaseModel):
-    a: Annotated[int, Gt(4)]
+class GreaterThanModel(BaseModel):
+    a: Annotated[int | None, GreaterThan(4)]
 
 
-class GeModel(BaseModel):
-    a: Annotated[int, Ge(4)]
+class GreaterEqualModel(BaseModel):
+    a: Annotated[int | None, GreaterEqual(4)]
 
 
-class LtModel(BaseModel):
-    a: Annotated[int, Lt(4)]
+class LessThanModel(BaseModel):
+    a: Annotated[int | None, LessThan(4)]
 
 
-class LeModel(BaseModel):
-    a: Annotated[int, Le(4)]
+class LessEqualModel(BaseModel):
+    a: Annotated[int | None, LessEqual(4)]
 
 
 class TestValidators:
@@ -30,29 +30,36 @@ class TestValidators:
             (3, pytest.raises(ValidationError)),
             (4, pytest.raises(ValidationError)),
             (5, nullcontext()),
+            (None, nullcontext()),
         ],
     )
     def test_greater_than(self, a, expectation):
-        """Test that the Gt validator validates correctly."""
+        """Test that the GreaterThan validator validates correctly."""
         with expectation:
-            GtModel(a=a)
+            GreaterThanModel(a=a)
 
     def test_greater_than_does_not_change_field_value(self):
-        """Test that the field value is not changed by the Gt validator."""
-        assert GtModel(a=7).a == 7
+        """Test that the field value is not changed by the GreaterThan validator."""
+        assert GreaterThanModel(a=7).a == 7
 
     @pytest.mark.parametrize(
         "a, expectation",
-        [(3, pytest.raises(ValidationError)), (4, nullcontext()), (5, nullcontext())],
+        [
+            (3, pytest.raises(ValidationError)),
+            (4, nullcontext()),
+            (5, nullcontext()),
+            (None, nullcontext()),
+        ],
     )
     def test_greater_equal(self, a, expectation):
-        """Test that the Ge validator validates correctly."""
+        """Test that the GreaterEqual validator validates correctly."""
         with expectation:
-            GeModel(a=a)
+            GreaterEqualModel(a=a)
 
     def test_greater_equal_does_not_change_field_value(self):
-        """Test that the field value is not changed by the Ge validator."""
-        assert GeModel(a=7).a == 7
+        """Test that the field value is not changed by the GreaterEqual validator."""
+        assert GreaterEqualModel(a=7).a == 7
+        assert GreaterEqualModel(a=None).a is None
 
     @pytest.mark.parametrize(
         "a, expectation",
@@ -60,26 +67,34 @@ class TestValidators:
             (3, nullcontext()),
             (4, pytest.raises(ValidationError)),
             (5, pytest.raises(ValidationError)),
+            (None, nullcontext()),
         ],
     )
     def test_less_than(self, a, expectation):
-        """Test that the Lt validator validates correctly."""
+        """Test that the LessThan validator validates correctly."""
         with expectation:
-            LtModel(a=a)
+            LessThanModel(a=a)
 
     def test_less_than_does_not_change_field_value(self):
-        """Test that the field value is not changed by the Lt validator."""
-        assert LtModel(a=2).a == 2
+        """Test that the field value is not changed by the LessThan validator."""
+        assert LessThanModel(a=2).a == 2
+        assert LessThanModel(a=None).a is None
 
     @pytest.mark.parametrize(
         "a, expectation",
-        [(3, nullcontext()), (4, nullcontext()), (5, pytest.raises(ValidationError))],
+        [
+            (3, nullcontext()),
+            (4, nullcontext()),
+            (5, pytest.raises(ValidationError)),
+            (None, nullcontext()),
+        ],
     )
     def test_less_equal(self, a, expectation):
-        """Test that the Le validator validates correctly."""
+        """Test that the LessEqual validator validates correctly."""
         with expectation:
-            LeModel(a=a)
+            LessEqualModel(a=a)
 
     def test_less_equal_does_not_change_field_value(self):
-        """Test that the field value is not changed by the Le validator."""
-        assert LeModel(a=2).a == 2
+        """Test that the field value is not changed by the LessEqual validator."""
+        assert LessEqualModel(a=2).a == 2
+        assert LessEqualModel(a=None).a is None


### PR DESCRIPTION
This PR addresses issue #55.
 
It adds a new class `AstropyQuantityTypeAnnotation`, which lets the user define custom types making use of AstroPy's `Quantity` class.

Tests for this new class are added, and the documentation on defining models is updated.