### PR TITLE
Suppress mypy errors due to untyped libraries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,27 +56,7 @@ reportAny = false
 reportMissingTypeStubs = false
 
 [[tool.mypy.overrides]]
-module = "annotated_types"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
 module = "astropy.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "httpx"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "pydantic.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "pydantic_core"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "pydantic_settings"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ lt = [
 ]
 
 [tool.pytest.ini_options]
-addopts = ["--import-mode=importlib",  "-m not online"]
+addopts = ["--import-mode=importlib", "-m not online"]
 markers = [
     "online: Marks tests that run online, for example, validating schemas",
     "side_effect: Online tests that have side effects such as creating observation requests",
@@ -54,3 +54,35 @@ exclude = [
 reportExplicitAny = false
 reportAny = false
 reportMissingTypeStubs = false
+
+[[tool.mypy.overrides]]
+module = "annotated_types"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "astropy.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "httpx"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pydantic.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pydantic_core"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pydantic_settings"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "p2api"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "suds.client"
+ignore_missing_imports = true


### PR DESCRIPTION
Several libraries used by AEONlib don't have type hints and therefore give errors when you type-check with mypy. The pyproject.toml file has been updated to tell mypy to ignore these libraries.

The only error remaining is for the lxml library. There exists a typing package for this library. I would suggest to add this as a dev dependency and remove it from the optional dependency group "lt".